### PR TITLE
added binutils submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "third_party/xbyak"]
 	path = third_party/xbyak
 	url = https://github.com/herumi/xbyak.git
+[submodule "third_party/binutils"]
+	path = third_party/binutils
+	url = git://sourceware.org/git/binutils.git

--- a/xenia-build.py
+++ b/xenia-build.py
@@ -364,7 +364,7 @@ def run_gyp(format):
       '--toplevel-dir=.',
       '--generator-output=build/xenia/',
       # Set the VS version.
-      '-G msvs_version=%s' % (os.environ['VSVERSION'] or 2013),
+      '-G msvs_version=%s' % (os.getenv('VSVERSION', 2013)),
       #'-D windows_sdk_dir=%s' % (os.environ['WINDOWSSDKDIR']),
       '-D windows_sdk_dir="C:\\Program Files (x86)\\Windows Kits\\8.1"',
       'xenia.gyp',


### PR DESCRIPTION
Was working to try and get things compiling on my mac last night, here's the first few minor issues I hit. I wasn't sure if binutils wasn't added just due to its size (it's a large clone), but alas:

 * added binutils submodule
 * default to 2013 when VSVERSION doesn't exist (using os.environ['missingkey'] throws exception)