### PR TITLE
libpoly: add missing include for thread_local define in logging.cc

### DIFF
--- a/src/poly/logging.cc
+++ b/src/poly/logging.cc
@@ -12,6 +12,7 @@
 #include <mutex>
 
 #include <gflags/gflags.h>
+#include <poly/cxx_compat.h>
 #include <poly/main.h>
 #include <poly/math.h>
 


### PR DESCRIPTION
Add a missing include in logging.cc that fixes the missing definition for
thread_local. Similar to issue #122.