### PR TITLE
Remove cxx_compat.h header

### DIFF
--- a/src/xenia/base/logging.cc
+++ b/src/xenia/base/logging.cc
@@ -13,7 +13,6 @@
 
 #include <mutex>
 
-#include "xenia/base/cxx_compat.h"
 #include "xenia/base/main.h"
 #include "xenia/base/math.h"
 #include "xenia/base/threading.h"

--- a/src/xenia/gpu/gl4/gl4_shader.cc
+++ b/src/xenia/gpu/gl4/gl4_shader.cc
@@ -9,7 +9,6 @@
 
 #include "xenia/gpu/gl4/gl4_shader.h"
 
-#include "xenia/base/cxx_compat.h"
 #include "xenia/base/logging.h"
 #include "xenia/base/math.h"
 #include "xenia/gpu/gl4/gl4_gpu-private.h"

--- a/src/xenia/gpu/gl4/gl_context.cc
+++ b/src/xenia/gpu/gl4/gl_context.cc
@@ -12,7 +12,6 @@
 #include <mutex>
 
 #include "xenia/base/assert.h"
-#include "xenia/base/cxx_compat.h"
 #include "xenia/base/logging.h"
 #include "xenia/base/math.h"
 #include "xenia/gpu/gl4/gl4_gpu-private.h"


### PR DESCRIPTION
Revert commits 6d159dc2 and 3f480d24. Visual Studio 2013 is not
supported anymore, so they are not needed.