### PR TITLE
More Audio Fixes

### DIFF
--- a/src/xenia/apu/audio_decoder.cc
+++ b/src/xenia/apu/audio_decoder.cc
@@ -200,15 +200,12 @@ int AudioDecoder::DecodePacket(uint8_t* output, size_t output_offset, size_t out
       for (int i = 0; i < decoded_frame_->nb_samples; i++) {
         // Raw sample should be within [-1, 1]
         float fRawSample = sample_array[i];
-        float fScaledSample = fRawSample * ((1 << bits_) - 1);
 
-        // Clamp the sample in range
-        int64_t range = (1 << bits_) * 2;
-        if (fScaledSample > (range - 1)) {
-          fScaledSample = (float)range;
-        } else if (fScaledSample < (-range + 1)) {
-          fScaledSample = (float)-range;
-        }
+        // Clamp it, just in case.
+        fRawSample = std::min( 1.f, fRawSample);
+        fRawSample = std::max(-1.f, fRawSample);
+
+        float fScaledSample = fRawSample * ((1 << bits_) - 1);
 
         // Convert the sample and output it in big endian
         int sample = (int)fScaledSample;

--- a/src/xenia/apu/audio_decoder.cc
+++ b/src/xenia/apu/audio_decoder.cc
@@ -22,7 +22,7 @@ extern "C" {
 namespace xe {
 namespace apu {
 
-AudioDecoder::AudioDecoder() : offset_(0), codec_(nullptr), context_(nullptr),
+AudioDecoder::AudioDecoder() : codec_(nullptr), context_(nullptr),
                               decoded_frame_(nullptr), packet_(nullptr) {}
 
 AudioDecoder::~AudioDecoder() {
@@ -100,7 +100,7 @@ int AudioDecoder::Initialize(int bits) {
   return 0;
 }
 
-int AudioDecoder::PreparePacket(uint8_t* input, size_t size,
+int AudioDecoder::PreparePacket(uint8_t* input, size_t seq_offset, size_t size,
                                 int sample_rate, int channels) {
   if (size != XMAContextData::kBytesPerBlock) {
     // Invalid packet size!
@@ -115,9 +115,8 @@ int AudioDecoder::PreparePacket(uint8_t* input, size_t size,
   std::memcpy(packet_data_, input, size);
 
   // Modify the packet header so it's WMAPro compatible
-  *((int *)packet_data_) = (((offset_ & 0x7800) | 0x400) >> 7) |
+  *((int *)packet_data_) = (((seq_offset & 0x7800) | 0x400) >> 7) |
                            (*((int*)packet_data_) & 0xFFFEFF08);
-  offset_ += XMAContextData::kBytesPerBlock; // Sequence number
 
   packet_->data = packet_data_;
   packet_->size = XMAContextData::kBytesPerBlock;
@@ -201,10 +200,10 @@ int AudioDecoder::DecodePacket(uint8_t* output, size_t output_offset, size_t out
       for (int i = 0; i < decoded_frame_->nb_samples; i++) {
         // Raw sample should be within [-1, 1]
         float fRawSample = sample_array[i];
-        float fScaledSample = fRawSample * (1 << (bits_ - 1));
+        float fScaledSample = fRawSample * ((1 << bits_) - 1);
 
         // Clamp the sample in range
-        int64_t range = (1 << (bits_ - 1));
+        int64_t range = (1 << bits_) * 2;
         if (fScaledSample > (range - 1)) {
           fScaledSample = (float)range;
         } else if (fScaledSample < (-range + 1)) {

--- a/src/xenia/apu/audio_decoder.h
+++ b/src/xenia/apu/audio_decoder.h
@@ -38,7 +38,8 @@ class AudioDecoder {
 
     int Initialize(int bits);
 
-    int PreparePacket(uint8_t* input, size_t size, int sample_rate, int channels);
+    int PreparePacket(uint8_t* input, size_t seq_offset, size_t size,
+                      int sample_rate, int channels);
     void DiscardPacket();
 
     int DecodePacket(uint8_t* output, size_t offset, size_t size);
@@ -54,7 +55,6 @@ class AudioDecoder {
     size_t current_frame_pos_;
     uint8_t* current_frame_;
     uint32_t frame_samples_size_;
-    int offset_;
 
     uint8_t packet_data_[XMAContextData::kBytesPerBlock];
 };

--- a/src/xenia/apu/audio_system.cc
+++ b/src/xenia/apu/audio_system.cc
@@ -330,11 +330,6 @@ void AudioSystem::UnregisterClient(size_t index) {
 }
 
 void AudioSystem::ProcessXmaContext(XMAContext& context, XMAContextData& data) {
-  if (!context.in_use) {
-    // Skip unused contexts.
-    return;
-  }
-
   SCOPE_profile_cpu_f("apu");
 
   // Translate pointers for future use.

--- a/src/xenia/apu/audio_system.h
+++ b/src/xenia/apu/audio_system.h
@@ -200,6 +200,7 @@ class AudioSystem {
     uint32_t guest_ptr;
     xe::mutex lock;
     bool in_use;
+    bool kicked;
 
     AudioDecoder* decoder;
   };


### PR DESCRIPTION
- Fixes decoder accidentally clamping audio to half its original volume
- Select XMA buffer 1 if necessary (although it can't decode buffer 1 at all)
 - Asserts if buffer 1 is not NULL (game will stop waiting for the decoder if it isn't)

- context.kicked flag so the decoder only picks contexts that the game wants to be decoded.
