### PR TITLE
Fixes some issues on AMD drivers

### DIFF
--- a/src/xenia/gpu/gl4/blitter.cc
+++ b/src/xenia/gpu/gl4/blitter.cc
@@ -45,9 +45,6 @@ precision highp float; \n\
 precision highp int; \n\
 layout(std140, column_major) uniform; \n\
 layout(std430, column_major) buffer; \n\
-struct VertexData { \n\
-  vec2 uv; \n\
-}; \n\
 ";
   const std::string vs_source = header +
                                 "\n\
@@ -57,32 +54,29 @@ out gl_PerVertex { \n\
   float gl_PointSize; \n\
   float gl_ClipDistance[]; \n\
 }; \n\
-struct VertexFetch { \n\
-  vec2 pos; \n\
-};\n\
-layout(location = 0) in VertexFetch vfetch; \n\
-layout(location = 0) out VertexData vtx; \n\
+layout(location = 0) in vec2 vfetch_pos; \n\
+layout(location = 0) out vec2 vtx_uv; \n\
 void main() { \n\
-  gl_Position = vec4(vfetch.pos.xy * vec2(2.0, -2.0) - vec2(1.0, -1.0), 0.0, 1.0); \n\
-  vtx.uv = vfetch.pos.xy * src_uv.zw + src_uv.xy; \n\
+  gl_Position = vec4(vfetch_pos.xy * vec2(2.0, -2.0) - vec2(1.0, -1.0), 0.0, 1.0); \n\
+  vtx_uv = vfetch_pos.xy * src_uv.zw + src_uv.xy; \n\
 } \n\
 ";
   const std::string color_fs_source = header +
                                       "\n\
 layout(location = 1) uniform sampler2D src_texture; \n\
-layout(location = 0) in VertexData vtx; \n\
+layout(location = 0) in vec2 vtx_uv; \n\
 layout(location = 0) out vec4 oC; \n\
 void main() { \n\
-  oC = texture(src_texture, vtx.uv); \n\
+  oC = texture(src_texture, vtx_uv); \n\
 } \n\
 ";
   const std::string depth_fs_source = header +
                                       "\n\
 layout(location = 1) uniform sampler2D src_texture; \n\
-layout(location = 0) in VertexData vtx; \n\
+layout(location = 0) in vec2 vtx_uv; \n\
 layout(location = 0) out vec4 oC; \n\
 void main() { \n\
-  gl_FragDepth = texture(src_texture, vtx.uv).r; \n\
+  gl_FragDepth = texture(src_texture, vtx_uv).r; \n\
 } \n\
 ";
 

--- a/src/xenia/gpu/gl4/blitter.cc
+++ b/src/xenia/gpu/gl4/blitter.cc
@@ -180,7 +180,7 @@ struct SavedState {
     glGetIntegerv(GL_PROGRAM_PIPELINE_BINDING, &program_pipeline);
     glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &vertex_array);
     glGetIntegerv(GL_TEXTURE_BINDING_2D, &texture_0);
-    glGetIntegeri_v(GL_SAMPLER_BINDING, 0, &sampler_0);
+    glGetIntegerv(GL_SAMPLER_BINDING, &sampler_0);
   }
 
   void Restore() {

--- a/src/xenia/gpu/gl4/gl4_profiler_display.cc
+++ b/src/xenia/gpu/gl4/gl4_profiler_display.cc
@@ -252,44 +252,39 @@ precision highp float; \n\
 precision highp int; \n\
 layout(std140, column_major) uniform; \n\
 layout(std430, column_major) buffer; \n\
-struct VertexData { \n\
-  vec4 color; \n\
-  vec2 uv; \n\
-};\n\
 ";
   const std::string vertex_shader_source = header +
                                            "\n\
 layout(location = 0) uniform mat4 projection_matrix; \n\
-struct VertexFetch { \n\
-  vec2 pos; \n\
-  vec4 color; \n\
-  vec2 uv; \n\
-}; \n\
-layout(location = 0) in VertexFetch vfetch; \n\
-layout(location = 0) out VertexData vtx; \n\
+layout(location = 0) in vec2 in_pos; \n\
+layout(location = 1) in vec4 in_color; \n\
+layout(location = 2) in vec2 in_uv; \n\
+layout(location = 0) out vec4 vtx_color; \n\
+layout(location = 1) out vec2 vtx_uv; \n\
 void main() { \n\
-  gl_Position = projection_matrix * vec4(vfetch.pos.xy, 0.0, 1.0); \n\
-	vtx.color = vfetch.color; \n\
-	vtx.uv = vfetch.uv; \n\
+  gl_Position = projection_matrix * vec4(in_pos.xy, 0.0, 1.0); \n\
+  vtx_color = in_color; \n\
+  vtx_uv = in_uv; \n\
 } \n\
 ";
   const std::string fragment_shader_source = header +
                                              "\n\
 layout(location = 1, bindless_sampler) uniform sampler2D font_texture; \n\
 layout(location = 2) uniform float font_height; \n\
-layout(location = 0) in VertexData vtx; \n\
+layout(location = 0) in vec4 vtx_color; \n\
+layout(location = 1) in vec2 vtx_uv; \n\
 layout(location = 0) out vec4 oC; \n\
 void main() { \n\
-	if (vtx.uv.x > 1.0) { \n\
-		oC = vtx.color; \n\
-	} else { \n\
-	  vec4 color = texture(font_texture, vtx.uv); \n\
-		oC = color.rgba * vtx.color; \n\
-		if (color.a < 0.5) { \n\
-		  vec4 c1 = texture(font_texture, vtx.uv + vec2(0.0, font_height)); \n\
-			oC = vec4(0, 0, 0, c1.a); \n\
-		} \n\
-	} \n\
+  if (vtx_uv.x > 1.0) { \n\
+    oC = vtx_color; \n\
+  } else { \n\
+    vec4 color = texture(font_texture, vtx_uv); \n\
+    oC = color.rgba * vtx_color; \n\
+    if (color.a < 0.5) { \n\
+      vec4 c1 = texture(font_texture, vtx_uv + vec2(0.0, font_height)); \n\
+      oC = vec4(0, 0, 0, c1.a); \n\
+    } \n\
+  } \n\
 } \n\
 ";
 

--- a/src/xenia/gpu/gl4/gl4_shader.cc
+++ b/src/xenia/gpu/gl4/gl4_shader.cc
@@ -424,7 +424,11 @@ bool GL4Shader::CompileProgram(std::string source) {
       search_offset = p - search_start;
       ++search_offset;
     }
-    host_disassembly_ = std::string(disasm_start);
+    if (disasm_start) {
+      host_disassembly_ = std::string(disasm_start);
+    } else {
+      host_disassembly_ = std::string("Shader disassembly not available.");
+    }
 
     // Append to shader dump.
     if (FLAGS_dump_shaders.size()) {


### PR DESCRIPTION
These three commits are to fix some issues seen when trying to run on AMD video cards. For reference, this is Catalyst 15.200.1018 on Win8.1.

It's not perfect as there is still OpenGL errors being thrown, but at least the profiler display works now.

For the structs as in/out, there are still some present in command_processor.cc and gl4_shader.cc, but no errors are being thrown?? I guess we'll see if those parts will need to change too.