### PR TITLE
Log DebugPrint traps to debugger

### DIFF
--- a/src/xenia/base/debugging.h
+++ b/src/xenia/base/debugging.h
@@ -25,6 +25,8 @@ bool IsDebuggerAttached();
 // If no debugger is present, a signal will be raised.
 void Break();
 
+void DebugPrint(const char *fmt, ...);
+
 }  // namespace debugging
 }  // namespace xe
 

--- a/src/xenia/base/debugging_win.cc
+++ b/src/xenia/base/debugging_win.cc
@@ -8,6 +8,7 @@
  */
 
 #include "xenia/base/debugging.h"
+#include "xenia/base/string_buffer.h"
 
 #include <Windows.h>
 
@@ -17,6 +18,17 @@ namespace debugging {
 bool IsDebuggerAttached() { return IsDebuggerPresent() ? true : false; }
 
 void Break() { __debugbreak(); }
+
+void DebugPrint(const char *fmt, ...) {
+  StringBuffer buff;
+
+  va_list va;
+  va_start(va, fmt);
+  buff.AppendVarargs(fmt, va);
+  va_end(va);
+
+  OutputDebugStringA(buff.GetString());
+}
 
 }  // namespace debugging
 }  // namespace xe

--- a/src/xenia/cpu/backend/x64/x64_emitter.cc
+++ b/src/xenia/cpu/backend/x64/x64_emitter.cc
@@ -13,6 +13,7 @@
 
 #include "xenia/base/assert.h"
 #include "xenia/base/atomic.h"
+#include "xenia/base/debugging.h"
 #include "xenia/base/logging.h"
 #include "xenia/base/math.h"
 #include "xenia/base/memory.h"
@@ -33,6 +34,9 @@
 DEFINE_bool(
     enable_haswell_instructions, true,
     "Uses the AVX2/FMA/etc instructions on Haswell processors, if available.");
+
+DEFINE_bool(enable_debugprint_log, false,
+            "Log debugprint traps to the active debugger");
 
 namespace xe {
 namespace cpu {
@@ -292,6 +296,11 @@ uint64_t TrapDebugPrint(void* raw_context, uint64_t address) {
   auto str = thread_state->memory()->TranslateVirtual<const char*>(str_ptr);
   // TODO(benvanik): truncate to length?
   XELOGD("(DebugPrint) %s", str);
+
+  if (FLAGS_enable_debugprint_log) {
+    debugging::DebugPrint("(DebugPrint) %s\n", str);
+  }
+
   return 0;
 }
 


### PR DESCRIPTION
* Protected with a flag w/ default of false, since logging to debugger is apparently super duper slow