### PR TITLE
gl4: command_processor: fix locations in geometry shader header

### DIFF
--- a/src/xenia/gpu/gl4/command_processor.cc
+++ b/src/xenia/gpu/gl4/command_processor.cc
@@ -276,8 +276,8 @@ bool CommandProcessor::SetupGL() {
       "  vec4 o[16];\n"
       "};\n"
       "\n"
-      "layout(location = 0) in VertexData in_vtx[];\n"
-      "layout(location = 0) out VertexData out_vtx;\n";
+      "layout(location = 1) in VertexData in_vtx[];\n"
+      "layout(location = 1) out VertexData out_vtx;\n";
   // TODO(benvanik): fetch default point size from register and use that if
   //     the VS doesn't write oPointSize.
   // TODO(benvanik): clamp to min/max.


### PR DESCRIPTION
While trying to debug an OpenGL error on AMD, I found out that the following was logged in the pipeline infolog after a validation of the pipeline:

    in_vtx.o[0]'s data type or qualifiers doesn't match between vertex shader and geometry shader
    draw_id's data type or qualifiers doesn't match between geometry shader and fragment shader

Basically, as described in the commit message, the Geometry shader has the wrong layout value for its VertexData input/output, compared to the Vertex and Pixel shaders.

Unfortunately, this does not fix the error I was debugging...

Also, this should probably be tested before merging by someone who can display something (i.e. someone with a nVidia card), to make sure it still works. I was not able to, for obvious reasons...