### PR TITLE
gl4 : clear depth and stencil seperately using the DSA version

### DIFF
--- a/src/xenia/gpu/gl4/command_processor.cc
+++ b/src/xenia/gpu/gl4/command_processor.cc
@@ -2871,21 +2871,16 @@ bool CommandProcessor::IssueCopy() {
     // TODO(benvanik): verify format.
     GLfloat depth = {(copy_depth_clear & 0xFFFFFF00) / float(0xFFFFFF00)};
     GLint stencil = copy_depth_clear & 0xFF;
-    GLint old_draw_framebuffer;
     GLboolean old_depth_mask;
     GLint old_stencil_mask;
-    glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &old_draw_framebuffer);
     glGetBooleanv(GL_DEPTH_WRITEMASK, &old_depth_mask);
     glGetIntegerv(GL_STENCIL_WRITEMASK, &old_stencil_mask);
-    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, source_framebuffer->framebuffer);
     glDepthMask(GL_TRUE);
     glStencilMask(0xFF);
-    // HACK: this should work, but throws INVALID_ENUM on nvidia drivers.
-    /* glClearNamedFramebufferfi(source_framebuffer->framebuffer,
-                             GL_DEPTH_STENCIL,
-                             depth, stencil);*/
-    glClearBufferfi(GL_DEPTH_STENCIL, 0, depth, stencil);
-    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, old_draw_framebuffer);
+    glClearNamedFramebufferfv(source_framebuffer->framebuffer, GL_DEPTH,
+                              0, @depth);
+    glClearNamedFramebufferiv(source_framebuffer->framebuffer, GL_STENCIL,
+                              0, #stencil);                           
     glDepthMask(old_depth_mask);
     glStencilMask(old_stencil_mask);
   }

--- a/src/xenia/gpu/gl4/command_processor.cc
+++ b/src/xenia/gpu/gl4/command_processor.cc
@@ -2877,6 +2877,10 @@ bool CommandProcessor::IssueCopy() {
     glGetIntegerv(GL_STENCIL_WRITEMASK, &old_stencil_mask);
     glDepthMask(GL_TRUE);
     glStencilMask(0xFF);
+    // HACK: this should work, but throws INVALID_ENUM on nvidia drivers.
+    /* glClearNamedFramebufferfi(source_framebuffer->framebuffer,
+                             GL_DEPTH_STENCIL,
+                             depth, stencil);*/
     glClearNamedFramebufferfv(source_framebuffer->framebuffer, GL_DEPTH,
                               0, &depth);
     glClearNamedFramebufferiv(source_framebuffer->framebuffer, GL_STENCIL,

--- a/src/xenia/gpu/gl4/command_processor.cc
+++ b/src/xenia/gpu/gl4/command_processor.cc
@@ -2878,9 +2878,9 @@ bool CommandProcessor::IssueCopy() {
     glDepthMask(GL_TRUE);
     glStencilMask(0xFF);
     glClearNamedFramebufferfv(source_framebuffer->framebuffer, GL_DEPTH,
-                              0, @depth);
+                              0, &depth);
     glClearNamedFramebufferiv(source_framebuffer->framebuffer, GL_STENCIL,
-                              0, #stencil);                           
+                              0, &stencil);                           
     glDepthMask(old_depth_mask);
     glStencilMask(old_stencil_mask);
   }


### PR DESCRIPTION
Tested with RR 6 (w/ forcing depth_color_enabled)