### PR TITLE
XEX2 Code Refactoring

### DIFF
--- a/src/xenia/base/byte_order.h
+++ b/src/xenia/base/byte_order.h
@@ -12,6 +12,7 @@
 
 #include <cstdint>
 
+#include "xenia/base/assert.h"
 #include "xenia/base/platform.h"
 
 #if XE_PLATFORM_MAC

--- a/src/xenia/cpu/xex_module.cc
+++ b/src/xenia/cpu/xex_module.cc
@@ -361,6 +361,18 @@ bool XexModule::SetupLibraryImports(const char* name,
         uint8_t* p = memory()->TranslateVirtual(record_addr);
         xe::store_and_swap<uint32_t>(p + 0x0, 0x3D600000 | hi_addr);
         xe::store_and_swap<uint32_t>(p + 0x4, 0x616B0000 | low_addr);
+      } else {
+        // Import not resolved.
+        // We're gonna rewrite the PPC to trigger a debug trap:
+        //    trap
+        //    blr
+        //    nop
+        //    nop
+        uint8_t* p = memory()->TranslateVirtual(record_addr);
+        xe::store_and_swap<uint32_t>(p + 0x0, 0x7FE00008);
+        xe::store_and_swap<uint32_t>(p + 0x4, 0x4E800020);
+        xe::store_and_swap<uint32_t>(p + 0x8, 0x60000000);
+        xe::store_and_swap<uint32_t>(p + 0xC, 0x60000000);
       }
 
       fn_info->set_status(SymbolStatus::kDeclared);

--- a/src/xenia/cpu/xex_module.cc
+++ b/src/xenia/cpu/xex_module.cc
@@ -417,6 +417,8 @@ bool XexModule::SetupLibraryImports(const char* name,
                 (FunctionInfo::ExternHandler)kernel_export->function_data.shim;
           }
         } else {
+          XELOGW("WARNING: Imported kernel function %s is unimplemented!",
+                 import_name.GetString());
           handler = UndefinedImport;
         }
 

--- a/src/xenia/cpu/xex_module.cc
+++ b/src/xenia/cpu/xex_module.cc
@@ -362,6 +362,8 @@ bool XexModule::SetupLibraryImports(const char* name,
         }
       } else if (user_export_addr) {
         *record_slot = user_export_addr;
+      } else {
+        *record_slot = 0xF00DF00D;
       }
 
       // Setup a variable and define it.

--- a/src/xenia/cpu/xex_module.cc
+++ b/src/xenia/cpu/xex_module.cc
@@ -114,7 +114,7 @@ uint32_t XexModule::GetProcAddress(uint16_t ordinal) const {
   xex2_opt_data_directory* pe_export_directory = 0;
   if (GetOptHeader(XEX_HEADER_EXPORTS_BY_NAME, &pe_export_directory)) {
     auto e = memory()->TranslateVirtual<const X_IMAGE_EXPORT_DIRECTORY*>(
-      *exe_address + pe_export_directory->offset);
+        *exe_address + pe_export_directory->offset);
     assert_not_null(e);
 
     uint32_t* function_table = (uint32_t*)((uint8_t*)e + e->AddressOfFunctions);

--- a/src/xenia/cpu/xex_module.cc
+++ b/src/xenia/cpu/xex_module.cc
@@ -78,6 +78,18 @@ bool XexModule::GetOptHeader(const xex2_header* header, xe_xex2_header_keys key,
   return false;
 }
 
+bool XexModule::GetOptHeader(xe_xex2_header_keys key, void** out_ptr) const {
+  return XexModule::GetOptHeader(xex_header_, key, out_ptr);
+}
+
+uint32_t XexModule::GetProcAddress(uint16_t ordinal) const {
+  return xe_xex2_lookup_export(xex_, ordinal);
+}
+
+uint32_t XexModule::GetProcAddress(const char* name) const {
+  return xe_xex2_lookup_export(xex_, name);
+}
+
 bool XexModule::ApplyPatch(XexModule* module) {
   auto header = reinterpret_cast<const xex2_header*>(module->xex_header());
   if (!(header->module_flags &

--- a/src/xenia/cpu/xex_module.h
+++ b/src/xenia/cpu/xex_module.h
@@ -34,6 +34,9 @@ class XexModule : public xe::cpu::Module {
 
   xe_xex2_ref xex() const { return xex_; }
   const xex2_header* xex_header() const { return xex_header_; }
+  const xex2_security_info* xex_security_info() const {
+    return GetSecurityInfo(xex_header_);
+  }
 
   // Gets an optional header. Returns NULL if not found.
   // Special case: if key & 0xFF == 0x00, this function will return the value,
@@ -41,6 +44,22 @@ class XexModule : public xe::cpu::Module {
   static bool GetOptHeader(const xex2_header* header, xe_xex2_header_keys key,
                            void** out_ptr);
   bool GetOptHeader(xe_xex2_header_keys key, void** out_ptr) const;
+
+  // Ultra-cool templated version
+  // Special case: if key & 0xFF == 0x00, this function will return the value,
+  // not a pointer!
+  template <typename T>
+  static bool GetOptHeader(const xex2_header* header, xe_xex2_header_keys key,
+                           T* out_ptr) {
+    return GetOptHeader(header, key, reinterpret_cast<void**>(out_ptr));
+  }
+
+  template <typename T>
+  bool GetOptHeader(xe_xex2_header_keys key, T* out_ptr) const {
+    return GetOptHeader(key, reinterpret_cast<void**>(out_ptr));
+  }
+
+  static const xex2_security_info* GetSecurityInfo(const xex2_header* header);
 
   uint32_t GetProcAddress(uint16_t ordinal) const;
   uint32_t GetProcAddress(const char* name) const;
@@ -55,8 +74,8 @@ class XexModule : public xe::cpu::Module {
   bool ContainsAddress(uint32_t address) override;
 
  private:
-  bool SetupImports(xe_xex2_ref xex);
-  bool SetupLibraryImports(const xe_xex2_import_library_t* library);
+  bool SetupLibraryImports(const char* name,
+                           const xex2_import_library* library);
   bool FindSaveRest();
 
  private:

--- a/src/xenia/cpu/xex_module.h
+++ b/src/xenia/cpu/xex_module.h
@@ -40,6 +40,10 @@ class XexModule : public xe::cpu::Module {
   // not a pointer!
   static bool GetOptHeader(const xex2_header* header, xe_xex2_header_keys key,
                            void** out_ptr);
+  bool GetOptHeader(xe_xex2_header_keys key, void** out_ptr) const;
+
+  uint32_t GetProcAddress(uint16_t ordinal) const;
+  uint32_t GetProcAddress(const char* name) const;
 
   bool ApplyPatch(XexModule* module);
   bool Load(const std::string& name, const std::string& path,

--- a/src/xenia/cpu/xex_module.h
+++ b/src/xenia/cpu/xex_module.h
@@ -14,6 +14,7 @@
 
 #include "xenia/cpu/module.h"
 #include "xenia/kernel/util/xex2.h"
+#include "xenia/kernel/util/xex2_info.h"
 
 namespace xe {
 
@@ -32,7 +33,17 @@ class XexModule : public xe::cpu::Module {
   virtual ~XexModule();
 
   xe_xex2_ref xex() const { return xex_; }
+  const xex2_header* xex_header() const { return xex_header_; }
 
+  // Gets an optional header. Returns NULL if not found.
+  // Special case: if key & 0xFF == 0x00, this function will return the value,
+  // not a pointer!
+  static bool GetOptHeader(const xex2_header* header, xe_xex2_header_keys key,
+                           void** out_ptr);
+
+  bool ApplyPatch(XexModule* module);
+  bool Load(const std::string& name, const std::string& path,
+            const void* xex_addr, size_t xex_length);
   bool Load(const std::string& name, const std::string& path, xe_xex2_ref xex);
 
   const std::string& name() const override { return name_; }
@@ -50,6 +61,7 @@ class XexModule : public xe::cpu::Module {
   std::string name_;
   std::string path_;
   xe_xex2_ref xex_;
+  xex2_header* xex_header_;
 
   uint32_t base_address_;
   uint32_t low_address_;

--- a/src/xenia/cpu/xex_module.h
+++ b/src/xenia/cpu/xex_module.h
@@ -40,14 +40,14 @@ class XexModule : public xe::cpu::Module {
 
   // Gets an optional header. Returns NULL if not found.
   // Special case: if key & 0xFF == 0x00, this function will return the value,
-  // not a pointer!
+  // not a pointer! This assumes out_ptr points to uint32_t.
   static bool GetOptHeader(const xex2_header* header, xe_xex2_header_keys key,
                            void** out_ptr);
   bool GetOptHeader(xe_xex2_header_keys key, void** out_ptr) const;
 
   // Ultra-cool templated version
   // Special case: if key & 0xFF == 0x00, this function will return the value,
-  // not a pointer!
+  // not a pointer! This assumes out_ptr points to uint32_t.
   template <typename T>
   static bool GetOptHeader(const xex2_header* header, xe_xex2_header_keys key,
                            T* out_ptr) {

--- a/src/xenia/kernel/kernel_state.cc
+++ b/src/xenia/kernel/kernel_state.cc
@@ -123,7 +123,7 @@ uint32_t KernelState::title_id() const {
 
   xex2_opt_execution_info* exec_info = 0;
   executable_module_->GetOptHeader(XEX_HEADER_EXECUTION_INFO,
-                                   (void**)&exec_info);
+                                   &exec_info);
 
   if (exec_info) {
     return exec_info->title_id;
@@ -202,7 +202,7 @@ void KernelState::SetExecutableModule(object_ref<XUserModule> module) {
   }
 
   xex2_opt_tls_info* tls_header = nullptr;
-  executable_module_->GetOptHeader(XEX_HEADER_TLS_INFO, (void**)&tls_header);
+  executable_module_->GetOptHeader(XEX_HEADER_TLS_INFO, &tls_header);
   if (tls_header) {
     auto pib = memory_->TranslateVirtual<ProcessInfoBlock*>(
         process_info_block_address_);

--- a/src/xenia/kernel/kernel_state.cc
+++ b/src/xenia/kernel/kernel_state.cc
@@ -122,8 +122,7 @@ uint32_t KernelState::title_id() const {
   assert_not_null(executable_module_);
 
   xex2_opt_execution_info* exec_info = 0;
-  executable_module_->GetOptHeader(XEX_HEADER_EXECUTION_INFO,
-                                   &exec_info);
+  executable_module_->GetOptHeader(XEX_HEADER_EXECUTION_INFO, &exec_info);
 
   if (exec_info) {
     return exec_info->title_id;

--- a/src/xenia/kernel/objects/xthread.cc
+++ b/src/xenia/kernel/objects/xthread.cc
@@ -586,11 +586,8 @@ void XThread::DeliverAPCs(void* data) {
       // kernel_routine(apc_address, &normal_routine, &normal_context,
       // &system_arg1, &system_arg2)
       uint64_t kernel_args[] = {
-          apc_ptr,
-          thread->scratch_address_ + 0,
-          thread->scratch_address_ + 4,
-          thread->scratch_address_ + 8,
-          thread->scratch_address_ + 12,
+          apc_ptr, thread->scratch_address_ + 0, thread->scratch_address_ + 4,
+          thread->scratch_address_ + 8, thread->scratch_address_ + 12,
       };
       processor->Execute(thread->thread_state(), apc->kernel_routine,
                          kernel_args, xe::countof(kernel_args));

--- a/src/xenia/kernel/objects/xthread.cc
+++ b/src/xenia/kernel/objects/xthread.cc
@@ -166,7 +166,7 @@ X_STATUS XThread::Create() {
   // Games will specify a certain number of 4b slots that each thread will get.
   xex2_opt_tls_info* tls_header = nullptr;
   if (module) {
-    module->GetOptHeader(XEX_HEADER_TLS_INFO, (void**)&tls_header);
+    module->GetOptHeader(XEX_HEADER_TLS_INFO, &tls_header);
   }
 
   const uint32_t kDefaultTlsSlotCount = 32;

--- a/src/xenia/kernel/objects/xuser_module.cc
+++ b/src/xenia/kernel/objects/xuser_module.cc
@@ -155,7 +155,8 @@ X_STATUS XUserModule::GetOptHeader(xe_xex2_header_keys key, void** out_ptr) {
 
 X_STATUS XUserModule::GetOptHeader(xe_xex2_header_keys key,
                                    uint32_t* out_header_guest_ptr) {
-  auto header = xex_module()->xex_header();
+  auto header =
+      memory()->TranslateVirtual<const xex2_header*>(guest_xex_header_);
   if (!header) {
     return X_STATUS_UNSUCCESSFUL;
   }

--- a/src/xenia/kernel/objects/xuser_module.cc
+++ b/src/xenia/kernel/objects/xuser_module.cc
@@ -102,10 +102,8 @@ X_STATUS XUserModule::LoadFromMemory(const void* addr, const size_t length) {
   ldr_data->xex_header_base = guest_xex_header_;
 
   // Cache some commonly used headers...
-  this->xex_module()->GetOptHeader(XEX_HEADER_ENTRY_POINT,
-                                   &entry_point_);
-  this->xex_module()->GetOptHeader(XEX_HEADER_DEFAULT_STACK_SIZE,
-                                   &stack_size_);
+  this->xex_module()->GetOptHeader(XEX_HEADER_ENTRY_POINT, &entry_point_);
+  this->xex_module()->GetOptHeader(XEX_HEADER_DEFAULT_STACK_SIZE, &stack_size_);
 
   OnLoad();
 
@@ -266,13 +264,15 @@ void XUserModule::Dump() {
         printf("  XEX_HEADER_BOUNDING_PATH: %s\n", opt_bound_path->path);
       } break;
       case XEX_HEADER_ORIGINAL_BASE_ADDRESS: {
-        printf("  XEX_HEADER_ORIGINAL_BASE_ADDRESS: %.8X\n", (uint32_t)opt_header.value);
+        printf("  XEX_HEADER_ORIGINAL_BASE_ADDRESS: %.8X\n",
+               (uint32_t)opt_header.value);
       } break;
       case XEX_HEADER_ENTRY_POINT: {
         printf("  XEX_HEADER_ENTRY_POINT: %.8X\n", (uint32_t)opt_header.value);
       } break;
       case XEX_HEADER_IMAGE_BASE_ADDRESS: {
-        printf("  XEX_HEADER_IMAGE_BASE_ADDRESS: %.8X\n", (uint32_t)opt_header.value);
+        printf("  XEX_HEADER_IMAGE_BASE_ADDRESS: %.8X\n",
+               (uint32_t)opt_header.value);
       } break;
       case XEX_HEADER_ORIGINAL_PE_NAME: {
         auto opt_pe_name =
@@ -298,19 +298,25 @@ void XUserModule::Dump() {
         auto opt_tls_info =
             reinterpret_cast<const xex2_opt_tls_info*>(opt_header_ptr);
 
-        printf("          Slot Count: %d\n", (uint32_t)opt_tls_info->slot_count);
-        printf("    Raw Data Address: %.8X\n", (uint32_t)opt_tls_info->raw_data_address);
+        printf("          Slot Count: %d\n",
+               (uint32_t)opt_tls_info->slot_count);
+        printf("    Raw Data Address: %.8X\n",
+               (uint32_t)opt_tls_info->raw_data_address);
         printf("           Data Size: %d\n", (uint32_t)opt_tls_info->data_size);
-        printf("       Raw Data Size: %d\n", (uint32_t)opt_tls_info->raw_data_size);
+        printf("       Raw Data Size: %d\n",
+               (uint32_t)opt_tls_info->raw_data_size);
       } break;
       case XEX_HEADER_DEFAULT_STACK_SIZE: {
-        printf("  XEX_HEADER_DEFAULT_STACK_SIZE: %d\n", (uint32_t)opt_header.value);
+        printf("  XEX_HEADER_DEFAULT_STACK_SIZE: %d\n",
+               (uint32_t)opt_header.value);
       } break;
       case XEX_HEADER_DEFAULT_FILESYSTEM_CACHE_SIZE: {
-        printf("  XEX_HEADER_DEFAULT_FILESYSTEM_CACHE_SIZE: %d\n", (uint32_t)opt_header.value);
+        printf("  XEX_HEADER_DEFAULT_FILESYSTEM_CACHE_SIZE: %d\n",
+               (uint32_t)opt_header.value);
       } break;
       case XEX_HEADER_DEFAULT_HEAP_SIZE: {
-        printf("  XEX_HEADER_DEFAULT_HEAP_SIZE: %d\n", (uint32_t)opt_header.value);
+        printf("  XEX_HEADER_DEFAULT_HEAP_SIZE: %d\n",
+               (uint32_t)opt_header.value);
       } break;
       case XEX_HEADER_PAGE_HEAP_SIZE_AND_FLAGS: {
         printf("  XEX_HEADER_PAGE_HEAP_SIZE_AND_FLAGS (TODO):\n");
@@ -347,238 +353,6 @@ void XUserModule::Dump() {
       } break;
     }
   }
-
-  /*
-  printf("    System Flags: %.8X\n", header->system_flags);
-  printf("\n");
-  printf("         Address: %.8X\n", header->exe_address);
-  printf("     Entry Point: %.8X\n", header->exe_entry_point);
-  printf("      Stack Size: %.8X\n", header->exe_stack_size);
-  printf("       Heap Size: %.8X\n", header->exe_heap_size);
-  printf("\n");
-  printf("  Execution Info:\n");
-  printf("        Media ID: %.8X\n", header->execution_info.media_id);
-  printf(
-      "         Version: %d.%d.%d.%d\n", header->execution_info.version.major,
-      header->execution_info.version.minor,
-      header->execution_info.version.build, header->execution_info.version.qfe);
-  printf("    Base Version: %d.%d.%d.%d\n",
-         header->execution_info.base_version.major,
-         header->execution_info.base_version.minor,
-         header->execution_info.base_version.build,
-         header->execution_info.base_version.qfe);
-  printf("        Title ID: %.8X\n", header->execution_info.title_id);
-  printf("        Platform: %.8X\n", header->execution_info.platform);
-  printf("      Exec Table: %.8X\n", header->execution_info.executable_table);
-  printf("     Disc Number: %d\n", header->execution_info.disc_number);
-  printf("      Disc Count: %d\n", header->execution_info.disc_count);
-  printf("     Savegame ID: %.8X\n", header->execution_info.savegame_id);
-  printf("\n");
-  printf("  Loader Info:\n");
-  printf("     Image Flags: %.8X\n", header->loader_info.image_flags);
-  printf("    Game Regions: %.8X\n", header->loader_info.game_regions);
-  printf("     Media Flags: %.8X\n", header->loader_info.media_flags);
-  printf("\n");
-  printf("  TLS Info:\n");
-  printf("      Slot Count: %d\n", header->tls_info.slot_count);
-  printf("       Data Size: %db\n", header->tls_info.data_size);
-  printf("         Address: %.8X, %db\n", header->tls_info.raw_data_address,
-         header->tls_info.raw_data_size);
-  printf("\n");
-  printf("  Headers:\n");
-  for (size_t n = 0; n < header->header_count; n++) {
-    const xex2_opt_header* opt_header = &header->headers[n];
-    printf("    %.8X (%.8X, %4db) %.8X = %11d\n", opt_header->key,
-           opt_header->offset, opt_header->length, opt_header->value,
-           opt_header->value);
-  }
-  printf("\n");
-
-  // Resources.
-  printf("Resources:\n");
-  for (size_t n = 0; n < header->resource_info_count; n++) {
-    auto& res = header->resource_infos[n];
-    printf("  %-8s %.8X-%.8X, %db\n", res.name, res.address,
-           res.address + res.size, res.size);
-  }
-  printf("\n");
-
-  // Section info.
-  printf("Sections:\n");
-  for (size_t n = 0, i = 0; n < header->section_count; n++) {
-    const xe_xex2_section_t* section = &header->sections[n];
-    const char* type = "UNKNOWN";
-    switch (section->info.type) {
-      case XEX_SECTION_CODE:
-        type = "CODE   ";
-        break;
-      case XEX_SECTION_DATA:
-        type = "RWDATA ";
-        break;
-      case XEX_SECTION_READONLY_DATA:
-        type = "RODATA ";
-        break;
-    }
-    const size_t start_address = header->exe_address + (i * section->page_size);
-    const size_t end_address =
-        start_address + (section->info.page_count * section->page_size);
-    printf("  %3d %s %3d pages    %.8X - %.8X (%d bytes)\n", (int)n, type,
-           section->info.page_count, (int)start_address, (int)end_address,
-           section->info.page_count * section->page_size);
-    i += section->info.page_count;
-  }
-  printf("\n");
-
-  // Static libraries.
-  printf("Static Libraries:\n");
-  for (size_t n = 0; n < header->static_library_count; n++) {
-    const xe_xex2_static_library_t* library = &header->static_libraries[n];
-    printf("  %-8s : %d.%d.%d.%d\n", library->name, library->major,
-           library->minor, library->build, library->qfe);
-  }
-  printf("\n");
-
-  // Exports.
-  printf("Exports:\n");
-  if (header->loader_info.export_table) {
-    printf(" XEX-style Ordinal Exports:\n");
-    auto export_table = reinterpret_cast<const xe_xex2_export_table*>(
-        memory()->TranslateVirtual(header->loader_info.export_table));
-    uint32_t ordinal_count = xe::byte_swap(export_table->count);
-    uint32_t ordinal_base = xe::byte_swap(export_table->base);
-    for (uint32_t i = 0, ordinal = ordinal_base; i < ordinal_count;
-         ++i, ++ordinal) {
-      uint32_t ordinal_offset = xe::byte_swap(export_table->ordOffset[i]);
-      ordinal_offset += xe::byte_swap(export_table->imagebaseaddr) << 16;
-      printf("     %.8X          %.3X (%3d)\n", ordinal_offset, ordinal,
-             ordinal);
-    }
-  }
-  if (header->pe_export_table_offset) {
-    auto e = reinterpret_cast<const IMAGE_EXPORT_DIRECTORY*>(
-        memory()->TranslateVirtual(header->exe_address +
-                                   header->pe_export_table_offset));
-    uint32_t* function_table = (uint32_t*)((uint64_t)e + e->AddressOfFunctions);
-    uint32_t* name_table = (uint32_t*)((uint64_t)e + e->AddressOfNames);
-    uint16_t* ordinal_table =
-        (uint16_t*)((uint64_t)e + e->AddressOfNameOrdinals);
-    const char* mod_name = (const char*)((uint64_t)e + e->Name);
-    printf(" PE %s:\n", mod_name);
-    for (uint32_t i = 0; i < e->NumberOfNames; i++) {
-      const char* fn_name = (const char*)((uint64_t)e + name_table[i]);
-      uint16_t ordinal = ordinal_table[i];
-      uint32_t addr = header->exe_address + function_table[ordinal];
-      printf("     %.8X          %.3X (%3d)    %s\n", addr, ordinal, ordinal,
-             fn_name);
-    }
-  }
-  if (!header->loader_info.export_table && !header->pe_export_table_offset) {
-    printf("  No exports\n");
-  }
-  printf("\n");
-
-  // Imports.
-  printf("Imports:\n");
-  for (size_t n = 0; n < header->import_library_count; n++) {
-    const xe_xex2_import_library_t* library = &header->import_libraries[n];
-
-    xe_xex2_import_info_t* import_infos;
-    size_t import_info_count;
-    if (!xe_xex2_get_import_infos(xex_, library, &import_infos,
-                                  &import_info_count)) {
-      printf(" %s - %d imports\n", library->name, (int)import_info_count);
-      printf("   Version: %d.%d.%d.%d\n", library->version.major,
-             library->version.minor, library->version.build,
-             library->version.qfe);
-      printf("   Min Version: %d.%d.%d.%d\n", library->min_version.major,
-             library->min_version.minor, library->min_version.build,
-             library->min_version.qfe);
-      printf("\n");
-
-      // Counts.
-      int known_count = 0;
-      int unknown_count = 0;
-      int impl_count = 0;
-      int unimpl_count = 0;
-      for (size_t m = 0; m < import_info_count; m++) {
-        const xe_xex2_import_info_t* info = &import_infos[m];
-
-        if (kernel_state_->IsKernelModule(library->name)) {
-          auto kernel_export =
-              export_resolver->GetExportByOrdinal(library->name, info->ordinal);
-          if (kernel_export) {
-            known_count++;
-            if (kernel_export->is_implemented()) {
-              impl_count++;
-            } else {
-              unimpl_count++;
-            }
-          } else {
-            unknown_count++;
-            unimpl_count++;
-          }
-        } else {
-          auto module = kernel_state_->GetModule(library->name);
-          if (module) {
-            uint32_t export_addr =
-                module->GetProcAddressByOrdinal(info->ordinal);
-            if (export_addr) {
-              impl_count++;
-              known_count++;
-            } else {
-              unimpl_count++;
-              unknown_count++;
-            }
-          } else {
-            unimpl_count++;
-            unknown_count++;
-          }
-        }
-      }
-      printf("         Total: %4u\n", uint32_t(import_info_count));
-      printf("         Known:  %3d%% (%d known, %d unknown)\n",
-             (int)(known_count / (float)import_info_count * 100.0f),
-             known_count, unknown_count);
-      printf("   Implemented:  %3d%% (%d implemented, %d unimplemented)\n",
-             (int)(impl_count / (float)import_info_count * 100.0f), impl_count,
-             unimpl_count);
-      printf("\n");
-
-      // Listing.
-      for (size_t m = 0; m < import_info_count; m++) {
-        const xe_xex2_import_info_t* info = &import_infos[m];
-        const char* name = "UNKNOWN";
-        bool implemented = false;
-
-        Export* kernel_export = nullptr;
-        if (kernel_state_->IsKernelModule(library->name)) {
-          kernel_export =
-              export_resolver->GetExportByOrdinal(library->name, info->ordinal);
-          if (kernel_export) {
-            name = kernel_export->name;
-            implemented = kernel_export->is_implemented();
-          }
-        } else {
-          auto module = kernel_state_->GetModule(library->name);
-          if (module && module->GetProcAddressByOrdinal(info->ordinal)) {
-            // TODO: Name lookup
-            implemented = true;
-          }
-        }
-        if (kernel_export && kernel_export->type == Export::Type::kVariable) {
-          printf("   V %.8X          %.3X (%3d) %s %s\n", info->value_address,
-                 info->ordinal, info->ordinal, implemented ? "  " : "!!", name);
-        } else if (info->thunk_address) {
-          printf("   F %.8X %.8X %.3X (%3d) %s %s\n", info->value_address,
-                 info->thunk_address, info->ordinal, info->ordinal,
-                 implemented ? "  " : "!!", name);
-        }
-      }
-    }
-
-    printf("\n");
-  }
-  */
 }
 
 }  // namespace kernel

--- a/src/xenia/kernel/objects/xuser_module.cc
+++ b/src/xenia/kernel/objects/xuser_module.cc
@@ -380,12 +380,9 @@ void XUserModule::Dump() {
         auto opt_exec_info =
             reinterpret_cast<const xex2_opt_execution_info*>(opt_header_ptr);
 
-        printf("       Media ID: %.8X\n",
-               (uint32_t)opt_exec_info->media_id);
-        printf("       Title ID: %.8X\n",
-               (uint32_t)opt_exec_info->title_id);
-        printf("    Savegame ID: %.8X\n",
-               (uint32_t)opt_exec_info->title_id);
+        printf("       Media ID: %.8X\n", (uint32_t)opt_exec_info->media_id);
+        printf("       Title ID: %.8X\n", (uint32_t)opt_exec_info->title_id);
+        printf("    Savegame ID: %.8X\n", (uint32_t)opt_exec_info->title_id);
         printf("    Disc Number / Total: %d / %d\n",
                (uint8_t)opt_exec_info->disc_number,
                (uint8_t)opt_exec_info->disc_count);
@@ -422,13 +419,15 @@ void XUserModule::Dump() {
             exe_address + dir->offset);
 
         // e->AddressOfX RVAs are relative to the IMAGE_EXPORT_DIRECTORY!
-        uint32_t* function_table = (uint32_t*)((uint64_t)e + e->AddressOfFunctions);
+        uint32_t* function_table =
+            (uint32_t*)((uint64_t)e + e->AddressOfFunctions);
 
         // Names relative to directory
         uint32_t* name_table = (uint32_t*)((uint64_t)e + e->AddressOfNames);
 
         // Table of ordinals (by name)
-        uint16_t* ordinal_table = (uint16_t*)((uint64_t)e + e->AddressOfNameOrdinals);
+        uint16_t* ordinal_table =
+            (uint16_t*)((uint64_t)e + e->AddressOfNameOrdinals);
 
         for (uint32_t i = 0; i < e->NumberOfNames; i++) {
           const char* name = (const char*)((uint8_t*)e + name_table[i]);

--- a/src/xenia/kernel/objects/xuser_module.cc
+++ b/src/xenia/kernel/objects/xuser_module.cc
@@ -327,13 +327,26 @@ void XUserModule::Dump() {
         printf("  XEX_HEADER_PAGE_HEAP_SIZE_AND_FLAGS (TODO):\n");
       } break;
       case XEX_HEADER_SYSTEM_FLAGS: {
-        printf("  XEX_HEADER_SYSTEM_FLAGS (TODO):\n");
+        printf("  XEX_HEADER_SYSTEM_FLAGS: %.8X\n", (uint32_t)opt_header.value);
       } break;
       case XEX_HEADER_EXECUTION_INFO: {
-        printf("  XEX_HEADER_EXECUTION_INFO (TODO):\n");
+        printf("  XEX_HEADER_EXECUTION_INFO:\n");
+        auto opt_exec_info =
+            reinterpret_cast<const xex2_opt_execution_info*>(opt_header_ptr);
+
+        printf("       Media ID: %.8X\n",
+               (uint32_t)opt_exec_info->media_id);
+        printf("       Title ID: %.8X\n",
+               (uint32_t)opt_exec_info->title_id);
+        printf("    Savegame ID: %.8X\n",
+               (uint32_t)opt_exec_info->title_id);
+        printf("    Disc Number / Total: %d / %d\n",
+               (uint8_t)opt_exec_info->disc_number,
+               (uint8_t)opt_exec_info->disc_count);
       } break;
       case XEX_HEADER_TITLE_WORKSPACE_SIZE: {
-        printf("  XEX_HEADER_TITLE_WORKSPACE_SIZE (TODO):\n");
+        printf("  XEX_HEADER_TITLE_WORKSPACE_SIZE: %d\n",
+               (uint32_t)opt_header.value);
       } break;
       case XEX_HEADER_GAME_RATINGS: {
         printf("  XEX_HEADER_GAME_RATINGS (TODO):\n");
@@ -351,7 +364,7 @@ void XUserModule::Dump() {
         printf("  XEX_HEADER_ALTERNATE_TITLE_IDS (TODO):\n");
       } break;
       case XEX_HEADER_ADDITIONAL_TITLE_MEMORY: {
-        printf("  XEX_HEADER_ADDITIONAL_TITLE_MEMORY (TODO):\n");
+        printf("  XEX_HEADER_ADDITIONAL_TITLE_MEMORY: %d\n", opt_header.value);
       } break;
       case XEX_HEADER_EXPORTS_BY_NAME: {
         printf("  XEX_HEADER_EXPORTS_BY_NAME:\n");

--- a/src/xenia/kernel/objects/xuser_module.h
+++ b/src/xenia/kernel/objects/xuser_module.h
@@ -13,15 +13,12 @@
 #include <string>
 
 #include "xenia/cpu/export_resolver.h"
+#include "xenia/cpu/xex_module.h"
 #include "xenia/kernel/objects/xmodule.h"
-#include "xenia/kernel/util/xex2.h"
+#include "xenia/kernel/util/xex2_info.h"
 #include "xenia/xbox.h"
 
 namespace xe {
-namespace cpu {
-class XexModule;
-}  // namespace cpu
-
 namespace kernel {
 
 class XUserModule : public XModule {
@@ -29,10 +26,14 @@ class XUserModule : public XModule {
   XUserModule(KernelState* kernel_state, const char* path);
   ~XUserModule() override;
 
-  const xe_xex2_header_t* xex_header();
   const xe::cpu::XexModule* xex_module() const {
     return reinterpret_cast<xe::cpu::XexModule*>(processor_module_);
   }
+
+  const xex2_header* xex_header() const { return xex_module()->xex_header(); }
+
+  uint32_t entry_point() const { return entry_point_; }
+  uint32_t stack_size() const { return stack_size_; }
 
   X_STATUS LoadFromFile(std::string path);
   X_STATUS LoadFromMemory(const void* addr, const size_t length);
@@ -41,6 +42,8 @@ class XUserModule : public XModule {
   uint32_t GetProcAddressByName(const char* name) override;
   X_STATUS GetSection(const char* name, uint32_t* out_section_data,
                       uint32_t* out_section_size) override;
+
+  X_STATUS GetOptHeader(xe_xex2_header_keys key, void** out_ptr);
 
   X_STATUS GetOptHeader(xe_xex2_header_keys key,
                         uint32_t* out_header_guest_ptr);
@@ -53,8 +56,10 @@ class XUserModule : public XModule {
   void Dump();
 
  private:
-  xe_xex2_ref xex_;
   uint32_t guest_xex_header_;
+
+  uint32_t entry_point_;
+  uint32_t stack_size_;
 };
 
 }  // namespace kernel

--- a/src/xenia/kernel/objects/xuser_module.h
+++ b/src/xenia/kernel/objects/xuser_module.h
@@ -18,6 +18,10 @@
 #include "xenia/xbox.h"
 
 namespace xe {
+namespace cpu {
+class XexModule;
+}  // namespace cpu
+
 namespace kernel {
 
 class XUserModule : public XModule {
@@ -25,8 +29,10 @@ class XUserModule : public XModule {
   XUserModule(KernelState* kernel_state, const char* path);
   ~XUserModule() override;
 
-  xe_xex2_ref xex();
   const xe_xex2_header_t* xex_header();
+  const xe::cpu::XexModule* xex_module() const {
+    return reinterpret_cast<xe::cpu::XexModule*>(processor_module_);
+  }
 
   X_STATUS LoadFromFile(std::string path);
   X_STATUS LoadFromMemory(const void* addr, const size_t length);
@@ -48,7 +54,7 @@ class XUserModule : public XModule {
 
  private:
   xe_xex2_ref xex_;
-  uint32_t xex_header_;
+  uint32_t guest_xex_header_;
 };
 
 }  // namespace kernel

--- a/src/xenia/kernel/objects/xuser_module.h
+++ b/src/xenia/kernel/objects/xuser_module.h
@@ -47,6 +47,12 @@ class XUserModule : public XModule {
   // Get optional header - FOR HOST USE ONLY!
   X_STATUS GetOptHeader(xe_xex2_header_keys key, void** out_ptr);
 
+  // Get optional header - FOR HOST USE ONLY!
+  template <typename T>
+  X_STATUS GetOptHeader(xe_xex2_header_keys key, T* out_ptr) {
+    return GetOptHeader(key, reinterpret_cast<void**>(out_ptr));
+  }
+
   // Get optional header that can safely be returned to guest code.
   X_STATUS GetOptHeader(xe_xex2_header_keys key,
                         uint32_t* out_header_guest_ptr);

--- a/src/xenia/kernel/objects/xuser_module.h
+++ b/src/xenia/kernel/objects/xuser_module.h
@@ -31,6 +31,7 @@ class XUserModule : public XModule {
   }
 
   const xex2_header* xex_header() const { return xex_module()->xex_header(); }
+  uint32_t guest_xex_header() const { return guest_xex_header_; }
 
   uint32_t entry_point() const { return entry_point_; }
   uint32_t stack_size() const { return stack_size_; }
@@ -43,8 +44,10 @@ class XUserModule : public XModule {
   X_STATUS GetSection(const char* name, uint32_t* out_section_data,
                       uint32_t* out_section_size) override;
 
+  // Get optional header - FOR HOST USE ONLY!
   X_STATUS GetOptHeader(xe_xex2_header_keys key, void** out_ptr);
 
+  // Get optional header that can safely be returned to guest code.
   X_STATUS GetOptHeader(xe_xex2_header_keys key,
                         uint32_t* out_header_guest_ptr);
   static X_STATUS GetOptHeader(uint8_t* membase, const xex2_header* header,

--- a/src/xenia/kernel/util/xex2.cc
+++ b/src/xenia/kernel/util/xex2.cc
@@ -28,11 +28,6 @@
 #include "xenia/base/platform.h"
 
 namespace xe {
-namespace kernel {
-uint32_t xex2_get_header_size(const xex2_header* header) {
-  return header->exe_offset;
-}
-}  // namespace kernel
 }  // namespace xe
 
 // TODO(benvanik): remove.
@@ -251,56 +246,59 @@ int xe_xex2_read_header(const uint8_t* addr, const size_t length,
         // size = xe::load_and_swap<uint32_t>(pp + 0x04);
       } break;
       case XEX_HEADER_IMPORT_LIBRARIES: {
-        const size_t max_count = xe::countof(header->import_libraries);
-        size_t count = xe::load_and_swap<uint32_t>(pp + 0x08);
+        auto import_libraries =
+            reinterpret_cast<const xe::xex2_opt_import_libraries *>(pp);
+
+        const uint32_t max_count = (uint32_t)xe::countof(header->import_libraries);
+        uint32_t count = import_libraries->library_count;
         assert_true(count <= max_count);
         if (count > max_count) {
           XELOGW("ignoring %zu extra entries in XEX_HEADER_IMPORT_LIBRARIES",
-                 (max_count - count));
+                 (max_count - import_libraries->library_count));
           count = max_count;
         }
         header->import_library_count = count;
 
-        uint32_t string_table_size = xe::load_and_swap<uint32_t>(pp + 0x04);
-        const char* string_table = (const char*)(pp + 0x0C);
+        uint32_t string_table_size = import_libraries->string_table_size;
+        const char *string_table[32]; // Pretend 32 is max_count
+        std::memset(string_table, 0, sizeof(string_table));
 
-        pp += 12 + string_table_size;
+        // Parse the string table
+        for (size_t i = 0, j = 0; i < string_table_size; j++) {
+          const char* str = import_libraries->string_table + i;
+
+          string_table[j] = str;
+          i += std::strlen(str) + 1;
+
+          // Padding
+          if ((i % 4) != 0) {
+            i += 4 - (i % 4);
+          }
+        }
+
+        pp += 12 + import_libraries->string_table_size;
         for (size_t m = 0; m < count; m++) {
           xe_xex2_import_library_t* library = &header->import_libraries[m];
+          auto src_library = (xe::xex2_import_library *)pp;
+
           memcpy(library->digest, pp + 0x04, 20);
-          library->import_id = xe::load_and_swap<uint32_t>(pp + 0x18);
-          library->version.value = xe::load_and_swap<uint32_t>(pp + 0x1C);
-          library->min_version.value = xe::load_and_swap<uint32_t>(pp + 0x20);
+          library->import_id = src_library->id;
+          library->version.value = src_library->version.value;
+          library->min_version.value = src_library->version_min.value;
 
-          const uint16_t name_index =
-              xe::load_and_swap<uint16_t>(pp + 0x24) & 0xFF;
-          for (size_t i = 0, j = 0; i < string_table_size;) {
-            assert_true(j <= 0xFF);
-            if (j == name_index) {
-              std::strncpy(library->name, string_table + i,
-                           xe::countof(library->name));
-              break;
-            }
-            if (string_table[i] == 0) {
-              i++;
-              if (i % 4) {
-                i += 4 - (i % 4);
-              }
-              j++;
-            } else {
-              i++;
-            }
-          }
+          std::strncpy(library->name,
+                       string_table[src_library->name_index],
+                       xe::countof(library->name));
 
-          library->record_count = xe::load_and_swap<uint16_t>(pp + 0x26);
+          library->record_count = src_library->count;
           library->records =
               (uint32_t*)calloc(library->record_count, sizeof(uint32_t));
           XEEXPECTNOTNULL(library->records);
-          pp += 0x28;
           for (size_t i = 0; i < library->record_count; i++) {
-            library->records[i] = xe::load_and_swap<uint32_t>(pp);
-            pp += 4;
+            library->records[i] = src_library->import_table[i];
           }
+
+          pp += src_library->size;
         }
       } break;
       case XEX_HEADER_STATIC_LIBRARIES: {
@@ -1058,17 +1056,17 @@ uint32_t xe_xex2_lookup_export(xe_xex2_ref xex, uint16_t ordinal) {
 
   // XEX-style export table.
   if (header->loader_info.export_table) {
-    auto export_table = reinterpret_cast<const xe_xex2_export_table*>(
+    auto export_table = reinterpret_cast<const xe::xex2_export_table *>(
         xex->memory->TranslateVirtual(header->loader_info.export_table));
-    uint32_t ordinal_count = xe::byte_swap(export_table->count);
-    uint32_t ordinal_base = xe::byte_swap(export_table->base);
+    uint32_t ordinal_count = export_table->count;
+    uint32_t ordinal_base = export_table->base;
     if (ordinal > ordinal_count) {
       XELOGE("xe_xex2_lookup_export: ordinal out of bounds");
       return 0;
     }
     uint32_t i = ordinal - ordinal_base;
-    uint32_t ordinal_offset = xe::byte_swap(export_table->ordOffset[i]);
-    ordinal_offset += xe::byte_swap(export_table->imagebaseaddr) << 16;
+    uint32_t ordinal_offset = export_table->ordOffset[i];
+    ordinal_offset += export_table->imagebaseaddr << 16;
     return ordinal_offset;
   }
 

--- a/src/xenia/kernel/util/xex2.cc
+++ b/src/xenia/kernel/util/xex2.cc
@@ -27,8 +27,7 @@
 #include "xenia/base/memory.h"
 #include "xenia/base/platform.h"
 
-namespace xe {
-}  // namespace xe
+namespace xe {}  // namespace xe
 
 // TODO(benvanik): remove.
 #define XEEXPECTZERO(expr) \
@@ -247,9 +246,10 @@ int xe_xex2_read_header(const uint8_t* addr, const size_t length,
       } break;
       case XEX_HEADER_IMPORT_LIBRARIES: {
         auto import_libraries =
-            reinterpret_cast<const xe::xex2_opt_import_libraries *>(pp);
+            reinterpret_cast<const xe::xex2_opt_import_libraries*>(pp);
 
-        const uint32_t max_count = (uint32_t)xe::countof(header->import_libraries);
+        const uint32_t max_count =
+            (uint32_t)xe::countof(header->import_libraries);
         uint32_t count = import_libraries->library_count;
         assert_true(count <= max_count);
         if (count > max_count) {
@@ -260,7 +260,7 @@ int xe_xex2_read_header(const uint8_t* addr, const size_t length,
         header->import_library_count = count;
 
         uint32_t string_table_size = import_libraries->string_table_size;
-        const char *string_table[32]; // Pretend 32 is max_count
+        const char* string_table[32];  // Pretend 32 is max_count
         std::memset(string_table, 0, sizeof(string_table));
 
         // Parse the string table
@@ -279,15 +279,14 @@ int xe_xex2_read_header(const uint8_t* addr, const size_t length,
         pp += 12 + import_libraries->string_table_size;
         for (size_t m = 0; m < count; m++) {
           xe_xex2_import_library_t* library = &header->import_libraries[m];
-          auto src_library = (xe::xex2_import_library *)pp;
+          auto src_library = (xe::xex2_import_library*)pp;
 
           memcpy(library->digest, pp + 0x04, 20);
           library->import_id = src_library->id;
           library->version.value = src_library->version.value;
           library->min_version.value = src_library->version_min.value;
 
-          std::strncpy(library->name,
-                       string_table[src_library->name_index],
+          std::strncpy(library->name, string_table[src_library->name_index],
                        xe::countof(library->name));
 
           library->record_count = src_library->count;
@@ -1056,7 +1055,7 @@ uint32_t xe_xex2_lookup_export(xe_xex2_ref xex, uint16_t ordinal) {
 
   // XEX-style export table.
   if (header->loader_info.export_table) {
-    auto export_table = reinterpret_cast<const xe::xex2_export_table *>(
+    auto export_table = reinterpret_cast<const xe::xex2_export_table*>(
         xex->memory->TranslateVirtual(header->loader_info.export_table));
     uint32_t ordinal_count = export_table->count;
     uint32_t ordinal_base = export_table->base;

--- a/src/xenia/kernel/util/xex2.h
+++ b/src/xenia/kernel/util/xex2.h
@@ -13,8 +13,7 @@
 #include "xenia/kernel/util/xex2_info.h"
 #include "xenia/memory.h"
 
-namespace xe {
-}  // namespace xe
+namespace xe {}  // namespace xe
 
 typedef struct { int reserved; } xe_xex2_options_t;
 

--- a/src/xenia/kernel/util/xex2.h
+++ b/src/xenia/kernel/util/xex2.h
@@ -14,9 +14,6 @@
 #include "xenia/memory.h"
 
 namespace xe {
-namespace kernel {
-uint32_t xex2_get_header_size(const xex2_header* header);
-}  // namespace kernel
 }  // namespace xe
 
 typedef struct { int reserved; } xe_xex2_options_t;

--- a/src/xenia/kernel/util/xex2_info.h
+++ b/src/xenia/kernel/util/xex2_info.h
@@ -586,24 +586,36 @@ struct xex2_header {
   xex2_opt_header headers[1];  // 0x18
 };
 
-struct xex2_security_info {
-  xe::be<uint32_t> header_size;          // 0x0
-  xe::be<uint32_t> image_size;           // 0x4
-  char rsa_signature[0x100];             // 0x8
-  xe::be<uint32_t> unk_108;              // 0x108 unk length
-  xe::be<uint32_t> image_flags;          // 0x10C
-  xe::be<uint32_t> load_address;         // 0x110
-  char section_digest[0x14];             // 0x114
-  xe::be<uint32_t> import_table_count;   // 0x128
-  char import_table_digest[0x14];        // 0x12C
-  char xgd2_media_id[0x10];              // 0x140
-  char aes_key[0x10];                    // 0x150
-  xe::be<uint32_t> export_table;         // 0x160
-  char header_digest[0x14];              // 0x164
-  xe::be<uint32_t> region;               // 0x178
-  xe::be<uint32_t> allowed_media_types;  // 0x17C
+struct xex2_page_descriptor {
+  union {
+    struct {
+      uint32_t info : 4;
+      uint32_t size : 28;
+    };
+    xe::be<uint32_t> value;  // 0x0
+  };
+  char data_digest[0x14];  // 0x4
 };
-static_assert_size(xex2_security_info, 0x180);
+
+struct xex2_security_info {
+  xe::be<uint32_t> header_size;              // 0x0
+  xe::be<uint32_t> image_size;               // 0x4
+  char rsa_signature[0x100];                 // 0x8
+  xe::be<uint32_t> unk_108;                  // 0x108 unk length
+  xe::be<uint32_t> image_flags;              // 0x10C
+  xe::be<uint32_t> load_address;             // 0x110
+  char section_digest[0x14];                 // 0x114
+  xe::be<uint32_t> import_table_count;       // 0x128
+  char import_table_digest[0x14];            // 0x12C
+  char xgd2_media_id[0x10];                  // 0x140
+  char aes_key[0x10];                        // 0x150
+  xe::be<uint32_t> export_table;             // 0x160
+  char header_digest[0x14];                  // 0x164
+  xe::be<uint32_t> region;                   // 0x178
+  xe::be<uint32_t> allowed_media_types;      // 0x17C
+  xe::be<uint32_t> page_descriptor_count;    // 0x180
+  xex2_page_descriptor page_descriptors[1];  // 0x184
+};
 
 struct xex2_export_table {
   xe::be<uint32_t> magic[3];         // 0x0

--- a/src/xenia/kernel/util/xex2_info.h
+++ b/src/xenia/kernel/util/xex2_info.h
@@ -480,6 +480,26 @@ union xex2_version {
   };
 };
 
+struct xex2_opt_tls_info {
+  xe::be<uint32_t> slot_count;        // 0x0
+  xe::be<uint32_t> raw_data_address;  // 0x4
+  xe::be<uint32_t> data_size;         // 0x8
+  xe::be<uint32_t> raw_data_size;     // 0xC
+};
+static_assert_size(xex2_opt_tls_info, 0x10);
+
+struct xex2_resource {
+  char name[8];              // 0x0
+  xe::be<uint32_t> address;  // 0x8
+  xe::be<uint32_t> size;     // 0xC
+};
+static_assert_size(xex2_resource, 0x10);
+
+struct xex2_opt_resource_info {
+  xe::be<uint32_t> size;       // 0x0 Resource count is (size - 4) / 16
+  xex2_resource resources[1];  // 0x4
+};
+
 struct xex2_opt_delta_patch_descriptor {
   xe::be<uint32_t> size;                         // 0x0
   xex2_version target_version;                   // 0x4

--- a/src/xenia/kernel/util/xex2_info.h
+++ b/src/xenia/kernel/util/xex2_info.h
@@ -628,6 +628,21 @@ struct xex2_export_table {
       ordOffset[1];  // 0x2C ordOffset[0] + (imagebaseaddr << 16) = function
 };
 
+// Little endian PE export directory (from winnt.h)
+struct X_IMAGE_EXPORT_DIRECTORY {
+  uint32_t Characteristics;
+  uint32_t TimeDateStamp;
+  uint16_t MajorVersion;
+  uint16_t MinorVersion;
+  uint32_t Name;
+  uint32_t Base;
+  uint32_t NumberOfFunctions;
+  uint32_t NumberOfNames;
+  uint32_t AddressOfFunctions;     // RVA from base of image
+  uint32_t AddressOfNames;         // RVA from base of image
+  uint32_t AddressOfNameOrdinals;  // RVA from base of image
+};
+
 }  // namespace xe
 
 #endif  // XENIA_KERNEL_XEX2_INFO_H_

--- a/src/xenia/kernel/util/xex2_info.h
+++ b/src/xenia/kernel/util/xex2_info.h
@@ -468,6 +468,37 @@ union xex2_version {
   };
 };
 
+struct xex2_opt_bound_path {
+  xe::be<uint32_t> size;
+  char path[1];
+};
+
+struct xex2_opt_static_library {
+  char name[8];                    // 0x0
+  xe::be<uint16_t> version_major;  // 0x8
+  xe::be<uint16_t> version_minor;  // 0xA
+  xe::be<uint16_t> version_build;  // 0xC
+  xe::be<uint8_t> approval_type;   // 0xE
+  xe::be<uint8_t> version_qfe;     // 0xF
+};
+static_assert_size(xex2_opt_static_library, 0x10);
+
+struct xex2_opt_static_libraries {
+  xe::be<uint32_t> size;                 // 0x0
+  xex2_opt_static_library libraries[1];  // 0x4
+};
+
+struct xex2_opt_original_pe_name {
+  xe::be<uint32_t> size;
+  char name[1];
+};
+
+struct xex2_opt_data_directory {
+  xe::be<uint32_t> offset;  // 0x0
+  xe::be<uint32_t> size;    // 0x4
+};
+static_assert_size(xex2_opt_data_directory, 0x8);
+
 struct xex2_opt_tls_info {
   xe::be<uint32_t> slot_count;        // 0x0
   xe::be<uint32_t> raw_data_address;  // 0x4

--- a/src/xenia/kernel/util/xex2_info.h
+++ b/src/xenia/kernel/util/xex2_info.h
@@ -297,18 +297,6 @@ typedef struct {
   xe_xex2_approval_type approval;
 } xe_xex2_static_library_t;
 
-// credits: some obscure pastebin (http://pastebin.com/ZRvr3Sgj)
-typedef struct {
-  uint32_t magic[3];
-  uint32_t modulenumber[2];
-  uint32_t version[3];
-  uint32_t imagebaseaddr;  // must be <<16 to be accurate
-  uint32_t count;
-  uint32_t base;
-  uint32_t ordOffset[1];  // ordOffset[0] + (imagebaseaddr << 16) = function
-                          // offset of ordinal 1
-} xe_xex2_export_table;
-
 typedef enum {
   XEX_ENCRYPTION_NONE = 0,
   XEX_ENCRYPTION_NORMAL = 1,
@@ -585,6 +573,18 @@ struct xex2_security_info {
   xe::be<uint32_t> allowed_media_types;  // 0x17C
 };
 static_assert_size(xex2_security_info, 0x180);
+
+struct xex2_export_table {
+  xe::be<uint32_t> magic[3];         // 0x0
+  xe::be<uint32_t> modulenumber[2];  // 0xC
+  xe::be<uint32_t> version[3];       // 0x14
+  xe::be<uint32_t> imagebaseaddr;    // 0x20 must be <<16 to be accurate
+  xe::be<uint32_t> count;            // 0x24
+  xe::be<uint32_t> base;             // 0x28
+  xe::be<uint32_t>
+      ordOffset[1];  // 0x2C ordOffset[0] + (imagebaseaddr << 16) = function
+};
+
 }  // namespace xe
 
 #endif  // XENIA_KERNEL_XEX2_INFO_H_

--- a/src/xenia/kernel/xboxkrnl_modules.cc
+++ b/src/xenia/kernel/xboxkrnl_modules.cc
@@ -141,9 +141,8 @@ SHIM_CALL XexCheckExecutablePrivilege_shim(PPCContext* ppc_context,
     SHIM_SET_RETURN_32(0);
     return;
   }
-  xe_xex2_ref xex = module->xex();
 
-  const xe_xex2_header_t* header = xe_xex2_get_header(xex);
+  auto header = module->xex_header();
   uint32_t result = (header->system_flags & mask) > 0;
 
   SHIM_SET_RETURN_32(result);

--- a/src/xenia/kernel/xboxkrnl_modules.cc
+++ b/src/xenia/kernel/xboxkrnl_modules.cc
@@ -143,7 +143,7 @@ SHIM_CALL XexCheckExecutablePrivilege_shim(PPCContext* ppc_context,
   }
 
   uint32_t flags = 0;
-  module->GetOptHeader(XEX_HEADER_SYSTEM_FLAGS, (void **)&flags);
+  module->GetOptHeader<uint32_t>(XEX_HEADER_SYSTEM_FLAGS, &flags);
 
   SHIM_SET_RETURN_32((flags & mask) > 0);
 }

--- a/src/xenia/kernel/xboxkrnl_modules.cc
+++ b/src/xenia/kernel/xboxkrnl_modules.cc
@@ -142,10 +142,10 @@ SHIM_CALL XexCheckExecutablePrivilege_shim(PPCContext* ppc_context,
     return;
   }
 
-  auto header = module->xex_header();
-  uint32_t result = (header->system_flags & mask) > 0;
+  uint32_t flags = 0;
+  module->GetOptHeader(XEX_HEADER_SYSTEM_FLAGS, (void **)&flags);
 
-  SHIM_SET_RETURN_32(result);
+  SHIM_SET_RETURN_32((flags & mask) > 0);
 }
 
 SHIM_CALL XexGetModuleHandle_shim(PPCContext* ppc_context,

--- a/src/xenia/kernel/xboxkrnl_threading.cc
+++ b/src/xenia/kernel/xboxkrnl_threading.cc
@@ -109,8 +109,7 @@ SHIM_CALL ExCreateThread_shim(PPCContext* ppc_context,
 
   // Inherit default stack size
   if (stack_size == 0) {
-    stack_size =
-        kernel_state->GetExecutableModule()->xex_header()->exe_stack_size;
+    stack_size = kernel_state->GetExecutableModule()->stack_size();
   }
 
   // Stack must be aligned to 16kb pages


### PR DESCRIPTION
* Removes most dependencies on xex2.c/.h
* Stores the xex2 header in host(XexModule) and guest(XUserModule) memory for direct access
 * Added a bunch of structs for direct access to xex2 headers
* If an import function is unresolved, rewrite the thunk to trigger a PPC trap and return to caller.

* Bad things:
 * Due to the way we're now resolving imports, we can't dump them to debug out anymore (except when loading the module). Should be fine though, the loading code will warn if importing an unimplemented variable/function.