### PR TITLE
gl4: use flag depth_clear_enabled

### DIFF
--- a/src/xenia/gpu/gl4/command_processor.cc
+++ b/src/xenia/gpu/gl4/command_processor.cc
@@ -2849,8 +2849,8 @@ bool CommandProcessor::IssueCopy() {
   // TODO(benvanik): figure out real condition here (maybe when color cleared?)
   // HACK: things seem to need their depth buffer cleared a lot more
   // than as indicated by the depth_clear_enabled flag.
-  // if (depth_clear_enabled) {
-  if (depth_target != kAnyTarget) {
+  if (depth_clear_enabled) {
+    // if (depth_target != kAnyTarget) {
     // Clear the current depth buffer.
     // TODO(benvanik): verify format.
     GLfloat depth = {(copy_depth_clear & 0xFFFFFF00) / float(0xFFFFFF00)};


### PR DESCRIPTION
This probably still not sufficiently to clear the depth buffer properly like RR but this helps Raiden IV to render in-game -correctly 


![raiden](https://cloud.githubusercontent.com/assets/3000282/8549049/38981ca2-24fb-11e5-95fc-a8a8c57cb3bb.jpg)
