### PR TITLE
gl4: fix texture format k_5_6_5

### DIFF
--- a/src/xenia/gpu/gl4/texture_cache.cc
+++ b/src/xenia/gpu/gl4/texture_cache.cc
@@ -41,7 +41,7 @@ static const TextureConfig texture_configs[64] = {
     {TextureFormat::k_8, GL_R8, GL_RED, GL_UNSIGNED_BYTE},
     {TextureFormat::k_1_5_5_5, GL_RGB5_A1, GL_RGBA,
      GL_UNSIGNED_SHORT_1_5_5_5_REV},
-    {TextureFormat::k_5_6_5, GL_RGB565, GL_RGB, GL_UNSIGNED_SHORT_5_6_5},
+    {TextureFormat::k_5_6_5, GL_RGB565, GL_RGB, GL_UNSIGNED_SHORT_5_6_5_REV},
     {TextureFormat::k_6_5_5, GL_INVALID_ENUM, GL_INVALID_ENUM, GL_INVALID_ENUM},
     {TextureFormat::k_8_8_8_8, GL_RGBA8, GL_RGBA, GL_UNSIGNED_BYTE},
     {TextureFormat::k_2_10_10_10, GL_RGB10_A2, GL_RGBA,


### PR DESCRIPTION
Tested with Naruto Shippuden Ultimate Ninja Storm 2 and character color looks okay now.

![naruto](https://cloud.githubusercontent.com/assets/3000282/8599592/f61c4ca0-2693-11e5-8c8a-aaed5684293f.jpg)


