### PR TITLE
Track object handle reference counts in the object table.

### DIFF
--- a/src/xenia/kernel/objects/xthread.cc
+++ b/src/xenia/kernel/objects/xthread.cc
@@ -292,6 +292,7 @@ X_STATUS XThread::Create() {
 
   // Always retain when starting - the thread owns itself until exited.
   Retain();
+  RetainHandle();
 
   xe::threading::Thread::CreationParameters params;
   params.stack_size = 16 * 1024 * 1024;  // Ignore game, always big!
@@ -350,6 +351,7 @@ X_STATUS XThread::Exit(int exit_code) {
 
   running_ = false;
   Release();
+  ReleaseHandle();
 
   // NOTE: this does not return!
   xe::threading::Thread::Exit(exit_code);
@@ -361,6 +363,7 @@ X_STATUS XThread::Terminate(int exit_code) {
 
   running_ = false;
   Release();
+  ReleaseHandle();
 
   thread_->Terminate(exit_code);
   return X_STATUS_SUCCESS;

--- a/src/xenia/kernel/xboxkrnl_ob.cc
+++ b/src/xenia/kernel/xboxkrnl_ob.cc
@@ -190,8 +190,7 @@ dword_result_t NtDuplicateObject(dword_t handle, lpdword_t new_handle_ptr,
 DECLARE_XBOXKRNL_EXPORT(NtDuplicateObject, ExportTag::kImplemented);
 
 dword_result_t NtClose(dword_t handle) {
-  // FIXME: This needs to be removed once handle count reaches 0!
-  return kernel_state()->object_table()->RemoveHandle(handle);
+  return kernel_state()->object_table()->ReleaseHandle(handle);
 }
 DECLARE_XBOXKRNL_EXPORT(NtClose, ExportTag::kImplemented);
 

--- a/src/xenia/kernel/xobject.h
+++ b/src/xenia/kernel/xobject.h
@@ -180,7 +180,6 @@ class XObject {
   KernelState* kernel_state_;
 
  private:
-  std::atomic<int32_t> handle_ref_count_;
   std::atomic<int32_t> pointer_ref_count_;
 
   Type type_;


### PR DESCRIPTION
* Should fix games that use NtClose like they're supposed to (such as xenia-project/game-compatibility#99)