### PR TITLE
Include host ID in XThread names

### DIFF
--- a/src/xenia/base/threading.h
+++ b/src/xenia/base/threading.h
@@ -343,6 +343,9 @@ class Thread : public WaitHandle {
   // threads that had been waiting for the thread to terminate.
   static void Exit(int exit_code);
 
+  // Returns the ID of the thread
+  virtual uint32_t id() const = 0;
+
   // Returns the current name of the thread, if previously specified.
   std::string name() const { return name_; }
 

--- a/src/xenia/base/threading_win.cc
+++ b/src/xenia/base/threading_win.cc
@@ -358,6 +358,7 @@ class Win32Thread : public Win32Handle<Thread> {
   }
 
   int32_t priority() override { return GetThreadPriority(handle_); }
+  uint32_t id() const override { return GetThreadId(handle_); }
 
   void set_priority(int32_t new_priority) override {
     SetThreadPriority(handle_, new_priority);

--- a/src/xenia/kernel/objects/xthread.h
+++ b/src/xenia/kernel/objects/xthread.h
@@ -103,6 +103,7 @@ class XThread : public XObject {
   virtual ~XThread();
 
   static bool IsInThread(XThread* other);
+  static bool IsInThread();
   static XThread* GetCurrentThread();
   static uint32_t GetCurrentThreadHandle();
   static uint32_t GetCurrentThreadId();


### PR DESCRIPTION
* Allows us to easily match XThreads in the VS debugger to lines in the log