### PR TITLE
[RFC] Fix crash when some games request too much memory

### DIFF
--- a/src/xenia/memory.cc
+++ b/src/xenia/memory.cc
@@ -615,6 +615,11 @@ bool BaseHeap::AllocRange(uint32_t low_address, uint32_t high_address,
   high_page_number =
       std::min(uint32_t(page_table_.size()) - 1, high_page_number);
 
+  if (page_count > (high_page_number - low_page_number)) {
+    XELOGE("BaseHeap::Alloc page count too big for requested range");
+    return false;
+  }
+
   std::lock_guard<xe::recursive_mutex> lock(heap_mutex_);
 
   // Find a free page range.


### PR DESCRIPTION
I put RFC because I am not sure if it's the proper way to fix this.

Some games appear to try to manually find the biggest chunk of memory they can get their hands on by repetitively calling MmAllocatePhysicalMemoryEx (and the associated free when the allocation succeeds).

Problem is that they start with an impossible size (1GB), as follows:
`d> 2970 MmAllocatePhysicalMemoryEx(0, 3FFFFFFF, 20000004, 00000000, FFFFFFFF, 00010000)`

This causes a memory acces violation crash in BaseHeap::AllocRange because we are out of range in page_table_. Make sure this doesn't happen by checking beforehand that the page count can fit in the requested page range.

The games that do this will hit the assert at https://github.com/benvanik/xenia/blob/master/src/xenia/memory.cc#L696 but they can continue without any problem. I was pondering on whether to remove that assert or not.

I saw this behaviour in games 534307EC (Tomb Raider Underworld) and 53510802 (Tomb Raider). Probably other games do that too.

Should help with xenia-project/game-compatibility#36