### PR TITLE
Fix the MMIO handler picking up invalid accesses outside of the mapped range

### DIFF
--- a/src/xenia/cpu/mmio_handler.h
+++ b/src/xenia/cpu/mmio_handler.h
@@ -42,7 +42,8 @@ class MMIOHandler {
   virtual ~MMIOHandler();
 
   static std::unique_ptr<MMIOHandler> Install(uint8_t* virtual_membase,
-                                              uint8_t* physical_membase);
+                                              uint8_t* physical_membase,
+                                              uint8_t* membase_end);
   static MMIOHandler* global_handler() { return global_handler_; }
 
   bool RegisterRange(uint32_t virtual_address, uint32_t mask, uint32_t size,
@@ -86,6 +87,7 @@ class MMIOHandler {
 
   uint8_t* virtual_membase_;
   uint8_t* physical_membase_;
+  uint8_t* memory_end_;
 
   std::vector<MMIORange> mapped_ranges_;
 

--- a/src/xenia/memory.cc
+++ b/src/xenia/memory.cc
@@ -184,8 +184,8 @@ int Memory::Initialize() {
       kMemoryProtectRead | kMemoryProtectWrite);
 
   // Add handlers for MMIO.
-  mmio_handler_ =
-      cpu::MMIOHandler::Install(virtual_membase_, physical_membase_);
+  mmio_handler_ = cpu::MMIOHandler::Install(virtual_membase_, physical_membase_,
+                                            physical_membase_ + 0x1FFFFFFF);
   if (!mmio_handler_) {
     XELOGE("Unable to install MMIO handlers");
     assert_always();


### PR DESCRIPTION
* Should prevent the MMIO handler double-crashing Xenia in an already invalid state.