### PR TITLE
Fixing some Linux build errors

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -45,7 +45,6 @@ filter("configurations:Debug")
     "_NO_DEBUG_HEAP=1",
   })
   runtime("Release")
-  linkoptions({"/NODEFAULTLIB:MSVCRTD"})
 
 filter("configurations:Release")
   runtime("Release")
@@ -58,7 +57,6 @@ filter("configurations:Release")
     "LinkTimeOptimization",
   })
   runtime("Release")
-  linkoptions({"/NODEFAULTLIB:MSVCRTD"})
 
 filter("platforms:Linux")
   system("linux")
@@ -96,7 +94,7 @@ filter("platforms:Windows")
     "_AMD64=1",
   })
   -- Ignores complaints about empty obj files:
-  linkoptions({"/ignore:4006", "/ignore:4221"})
+  linkoptions({"/ignore:4006", "/ignore:4221", "/NODEFAULTLIB:MSVCRTD"})
   links({
     "ntdll",
     "wsock32",

--- a/premake5.lua
+++ b/premake5.lua
@@ -64,8 +64,12 @@ filter("platforms:Linux")
   system("linux")
   toolset("clang")
   buildoptions({
-    "-std=c++14",
     "-mlzcnt",  -- Assume lzcnt supported.
+  })
+
+filter({"platforms:Linux", "language:C++"})
+  buildoptions({
+    "-std=c++14",
   })
 
 filter("platforms:Windows")

--- a/src/xenia/base/bit_stream.cc
+++ b/src/xenia/base/bit_stream.cc
@@ -10,6 +10,7 @@
 #include "xenia/base/bit_stream.h"
 
 #include <algorithm>
+#include <cstring>
 
 #include "xenia/base/assert.h"
 #include "xenia/base/byte_order.h"

--- a/src/xenia/base/bit_stream.h
+++ b/src/xenia/base/bit_stream.h
@@ -10,6 +10,7 @@
 #ifndef XENIA_BASE_BIT_STREAM_H_
 #define XENIA_BASE_BIT_STREAM_H_
 
+#include <cstddef>
 #include <cstdint>
 
 namespace xe {

--- a/src/xenia/base/memory.h
+++ b/src/xenia/base/memory.h
@@ -67,25 +67,21 @@ bool Protect(void* base_address, size_t length, PageAccess access,
 // The memory must be freed with AlignedFree.
 template <typename T>
 inline T* AlignedAlloc(size_t alignment) {
-#if __STDC_VERSION__ >= 201112L
-  return reinterpret_cast<T*>(aligned_alloc(alignment, sizeof(T)));
-#elif XE_COMPILER_MSVC
+#if XE_COMPILER_MSVC
   return reinterpret_cast<T*>(_aligned_malloc(sizeof(T), alignment));
 #else
-#error No aligned alloc.
-#endif  // __STDC_VERSION__ >= 201112L
+  return reinterpret_cast<T*>(aligned_alloc(alignment, sizeof(T)));
+#endif  // XE_COMPILER_MSVC
 }
 
 // Frees memory previously allocated with AlignedAlloc.
 template <typename T>
 void AlignedFree(T* ptr) {
-#if __STDC_VERSION__ >= 201112L
-  free(ptr);
-#elif XE_COMPILER_MSVC
+#if XE_COMPILER_MSVC
   _aligned_free(ptr);
 #else
-#error No aligned alloc.
-#endif  // __STDC_VERSION__ >= 201112L
+  free(ptr);
+#endif  // XE_COMPILER_MSVC
 }
 
 typedef void* FileMappingHandle;

--- a/src/xenia/base/string_util.h
+++ b/src/xenia/base/string_util.h
@@ -60,9 +60,11 @@ inline std::string to_hex_string(const vec128_t& value) {
 
 inline std::string to_hex_string(const __m128& value) {
   char buffer[128];
+  float f[4];
+  _mm_storeu_ps(f, value);
   std::snprintf(buffer, sizeof(buffer), "[%.8X, %.8X, %.8X, %.8X]",
-                value.m128_u32[0], value.m128_u32[1], value.m128_u32[2],
-                value.m128_u32[3]);
+                *(uint32_t *)&f[0], *(uint32_t *)&f[1], *(uint32_t *)&f[2],
+                *(uint32_t *)&f[3]);
   return std::string(buffer);
 }
 
@@ -179,6 +181,8 @@ inline vec128_t from_string<vec128_t>(const char* value, bool force_hex) {
 template <>
 inline __m128 from_string<__m128>(const char* value, bool force_hex) {
   __m128 v;
+  float f[4];
+  uint32_t u;
   char* p = const_cast<char*>(value);
   bool hex_mode = force_hex;
   if (*p == '[') {
@@ -193,22 +197,27 @@ inline __m128 from_string<__m128>(const char* value, bool force_hex) {
     ++p;
   }
   if (hex_mode) {
-    v.m128_u32[0] = std::strtoul(p, &p, 16);
+    u = std::strtoul(p, &p, 16);
+    f[0] = *(float *)&u;
     while (*p == ' ' || *p == ',') ++p;
-    v.m128_u32[1] = std::strtoul(p, &p, 16);
+    u = std::strtoul(p, &p, 16);
+    f[1] = *(float *)&u;
     while (*p == ' ' || *p == ',') ++p;
-    v.m128_u32[2] = std::strtoul(p, &p, 16);
+    u = std::strtoul(p, &p, 16);
+    f[2] = *(float *)&u;
     while (*p == ' ' || *p == ',') ++p;
-    v.m128_u32[3] = std::strtoul(p, &p, 16);
+    u = std::strtoul(p, &p, 16);
+    f[3] = *(float *)&u;
   } else {
-    v.m128_f32[0] = std::strtof(p, &p);
+    f[0] = std::strtof(p, &p);
     while (*p == ' ' || *p == ',') ++p;
-    v.m128_f32[1] = std::strtof(p, &p);
+    f[1] = std::strtof(p, &p);
     while (*p == ' ' || *p == ',') ++p;
-    v.m128_f32[2] = std::strtof(p, &p);
+    f[2] = std::strtof(p, &p);
     while (*p == ' ' || *p == ',') ++p;
-    v.m128_f32[3] = std::strtof(p, &p);
+    f[3] = std::strtof(p, &p);
   }
+  v = _mm_loadu_ps(f);
   return v;
 }
 

--- a/src/xenia/base/string_util.h
+++ b/src/xenia/base/string_util.h
@@ -70,8 +70,10 @@ inline std::string to_hex_string(const __m128& value) {
 
 inline std::string to_string(const __m128& value) {
   char buffer[128];
-  std::snprintf(buffer, sizeof(buffer), "(%F, %F, %F, %F)", value.m128_f32[0],
-                value.m128_f32[1], value.m128_f32[2], value.m128_f32[3]);
+  float f[4];
+  _mm_storeu_ps(f, value);
+  std::snprintf(buffer, sizeof(buffer), "(%F, %F, %F, %F)", f[0], f[1], f[2],
+                f[3]);
   return std::string(buffer);
 }
 

--- a/src/xenia/base/x64_context.h
+++ b/src/xenia/base/x64_context.h
@@ -12,6 +12,7 @@
 
 #include <cstdint>
 #include <string>
+#include <xmmintrin.h>
 
 namespace xe {
 

--- a/src/xenia/cpu/backend/x64/x64_sequences.cc
+++ b/src/xenia/cpu/backend/x64/x64_sequences.cc
@@ -411,6 +411,25 @@ struct I<OPCODE, DEST, SRC1, SRC2, SRC3> : DestField<DEST> {
   }
 };
 
+template <typename T>
+const T GetTempReg(X64Emitter& e);
+template <>
+const Reg8 GetTempReg<Reg8>(X64Emitter& e) {
+  return e.al;
+}
+template <>
+const Reg16 GetTempReg<Reg16>(X64Emitter& e) {
+  return e.ax;
+}
+template <>
+const Reg32 GetTempReg<Reg32>(X64Emitter& e) {
+  return e.eax;
+}
+template <>
+const Reg64 GetTempReg<Reg64>(X64Emitter& e) {
+  return e.rax;
+}
+
 template <typename SEQ, typename T>
 struct Sequence {
   typedef T EmitArgType;
@@ -628,25 +647,6 @@ struct Sequence {
     }
   }
 };
-
-template <typename T>
-const T GetTempReg(X64Emitter& e);
-template <>
-const Reg8 GetTempReg<Reg8>(X64Emitter& e) {
-  return e.al;
-}
-template <>
-const Reg16 GetTempReg<Reg16>(X64Emitter& e) {
-  return e.ax;
-}
-template <>
-const Reg32 GetTempReg<Reg32>(X64Emitter& e) {
-  return e.eax;
-}
-template <>
-const Reg64 GetTempReg<Reg64>(X64Emitter& e) {
-  return e.rax;
-}
 
 template <typename T>
 void Register() {

--- a/src/xenia/cpu/export_resolver.cc
+++ b/src/xenia/cpu/export_resolver.cc
@@ -28,9 +28,9 @@ ExportResolver::Table::Table(const char* module_name,
 
   exports_by_name_.reserve(exports_by_ordinal_->size());
   for (size_t i = 0; i < exports_by_ordinal_->size(); ++i) {
-    auto export = exports_by_ordinal_->at(i);
-    if (export) {
-      exports_by_name_.push_back(export);
+    auto ex = exports_by_ordinal_->at(i);
+    if (ex) {
+      exports_by_name_.push_back(ex);
     }
   }
   std::sort(
@@ -48,9 +48,9 @@ void ExportResolver::RegisterTable(
 
   all_exports_by_name_.reserve(all_exports_by_name_.size() + exports->size());
   for (size_t i = 0; i < exports->size(); ++i) {
-    auto export = exports->at(i);
-    if (export) {
-      all_exports_by_name_.push_back(export);
+    auto ex = exports->at(i);
+    if (ex) {
+      all_exports_by_name_.push_back(ex);
     }
   }
   std::sort(

--- a/src/xenia/debug/debugger.cc
+++ b/src/xenia/debug/debugger.cc
@@ -183,7 +183,7 @@ std::vector<ThreadExecutionInfo*> Debugger::QueryThreadExecutionInfos() {
 ThreadExecutionInfo* Debugger::QueryThreadExecutionInfo(
     uint32_t thread_handle) {
   auto global_lock = global_critical_region_.Acquire();
-  auto& it = thread_execution_infos_.find(thread_handle);
+  const auto& it = thread_execution_infos_.find(thread_handle);
   if (it == thread_execution_infos_.end()) {
     return nullptr;
   }

--- a/src/xenia/emulator.cc
+++ b/src/xenia/emulator.cc
@@ -282,7 +282,7 @@ bool Emulator::ExceptionCallback(Exception* ex) {
   auto code_end = code_base + code_cache->total_size();
 
   if (!debugger() ||
-      !debugger()->is_attached() && debugging::IsDebuggerAttached()) {
+      (!debugger()->is_attached() && debugging::IsDebuggerAttached())) {
     // If Xenia's debugger isn't attached but another one is, pass it to that
     // debugger.
     return false;

--- a/src/xenia/kernel/xobject.h
+++ b/src/xenia/kernel/xobject.h
@@ -280,11 +280,6 @@ class object_ref {
     return value;
   }
 
-  static void accept(T* value) {
-    reset(value);
-    value->Release();
-  }
-
   void reset() noexcept { object_ref().swap(*this); }
 
   void reset(T* value) noexcept { object_ref(value).swap(*this); }

--- a/third_party/capstone.lua
+++ b/third_party/capstone.lua
@@ -2,7 +2,7 @@ group("third_party")
 project("capstone")
   uuid("b3a89f7e-bb02-4945-ae75-219caed6afa2")
   kind("StaticLib")
-  language("C++")
+  language("C")
   links({
   })
   defines({

--- a/third_party/glew.lua
+++ b/third_party/glew.lua
@@ -2,7 +2,7 @@ group("third_party")
 project("glew")
   uuid("ca31d35a-6cf4-4c86-b97f-60b5244b80cb")
   kind("StaticLib")
-  language("C++")
+  language("C")
   links({
   })
   defines({

--- a/third_party/imgui.lua
+++ b/third_party/imgui.lua
@@ -22,6 +22,8 @@ project("imgui")
     "imgui/stb_textedit.h",
     "imgui/stb_truetype.h",
   })
+
+filter("platforms:Windows")
   buildoptions({
     "/wd4312",  -- Ugh.
   })

--- a/third_party/xxhash.lua
+++ b/third_party/xxhash.lua
@@ -2,7 +2,7 @@ group("third_party")
 project("xxhash")
   uuid("40d4ce21-5448-4399-9f98-589b7e1c23b1")
   kind("StaticLib")
-  language("C++")
+  language("C")
   links({
   })
   defines({

--- a/xenia-build
+++ b/xenia-build
@@ -503,8 +503,8 @@ class BaseBuildCommand(Command):
       print('ERROR: don\'t know how to build on this platform.')
     else:
       # TODO(benvanik): allow gcc?
-      os.environ['CXX'] = 'clang++-3.8'
-      os.environ['CC'] = 'clang++-3.8'
+      os.environ['CXX'] = 'clang++'
+      os.environ['CC'] = 'clang'
       result = shell_call([
           'make',
           '-Cbuild/',


### PR DESCRIPTION
This PR fixes some of the issues when trying to build under Linux with clang. All the third party stuff builds, and parts of xenia too (see issues tagged as cross platform for what doesn't build).

clang++ does not want to compile C code, so C projects were modified in their premake config and clang is used for these.

Three submodules have updates too, please also pull these. 
xenia-project/capstone
xenia-project/libav
xenia-project/elemental-forms

Please do tell if stuff is wrong and I will update ASAP.

For reference, I tested with Debian 8 and clang 3.5.