### PR TITLE
Use Clang 3.8 for Linux build.

### DIFF
--- a/building.md
+++ b/building.md
@@ -34,14 +34,13 @@ get helpful spacers/movs in the disassembly.
 
 ### Linux
 
-Linux support is extremely experimental and incomplete.
+Linux support is extremely experimental and presently incomplete.
 
-Only tested with GCC 4.9 on Ubuntu 14. [CodeLite](http://codelite.org) is the
-IDE of choice and `xb premake` will spit out files for that. Make also works via
-`xb build`.
+The build script uses LLVM/Clang 3.8. GCC should also work, but is not easily
+swappable right now.
 
-Currently building requires that CC == CXX == g++. If you know a way around this
-(to force .c files to be built with g++) let me know.
+[CodeLite](http://codelite.org) is the IDE of choice and `xb premake` will spit
+out files for that. Make also works via `xb build`.
 
 ## Running
 

--- a/src/xenia/cpu/elf_module.h
+++ b/src/xenia/cpu/elf_module.h
@@ -30,7 +30,7 @@ class ElfModule : public xe::cpu::Module {
 
   bool loaded() const { return loaded_; }
   uint32_t entry_point() const { return entry_point_; }
-  const std::string& name() const { return name_; }
+  const std::string& name() const override { return name_; }
   const std::string& path() const { return path_; }
 
   bool Load(const std::string& name, const std::string& path,

--- a/xenia-build
+++ b/xenia-build
@@ -503,8 +503,8 @@ class BaseBuildCommand(Command):
       print('ERROR: don\'t know how to build on this platform.')
     else:
       # TODO(benvanik): allow gcc?
-      os.environ['CXX'] = 'clang++'
-      os.environ['CC'] = 'clang'
+      os.environ['CXX'] = 'clang++-3.8'
+      os.environ['CC'] = 'clang-3.8'
       result = shell_call([
           'make',
           '-Cbuild/',


### PR DESCRIPTION
Specify Clang 3.8 for building under Linux. Fix a build error due to upgrading. Finally, update the Linux section of building.md. As mentionned, we can't build with GCC right now because Clang specific "no-error" flags are used. I guess compiler specific flags should be added in premake files.