### PR TITLE
Use guard pages for the MMIO handler rather than no access pages

### DIFF
--- a/src/xenia/base/exception_handler.h
+++ b/src/xenia/base/exception_handler.h
@@ -36,7 +36,8 @@ class Exception {
     code_ = Code::kIllegalInstruction;
     thread_context_ = thread_context;
   }
-  void InitializePageGuardViolation(X64Context* thread_context, uint64_t fault_address) {
+  void InitializePageGuardViolation(X64Context* thread_context,
+                                    uint64_t fault_address) {
     code_ = Code::kPageGuardViolation;
     thread_context_ = thread_context;
     fault_address_ = fault_address;

--- a/src/xenia/base/exception_handler.h
+++ b/src/xenia/base/exception_handler.h
@@ -23,6 +23,7 @@ class Exception {
     kInvalidException = 0,
     kAccessViolation,
     kIllegalInstruction,
+    kPageGuardViolation,
   };
 
   void InitializeAccessViolation(X64Context* thread_context,
@@ -34,6 +35,11 @@ class Exception {
   void InitializeIllegalInstruction(X64Context* thread_context) {
     code_ = Code::kIllegalInstruction;
     thread_context_ = thread_context;
+  }
+  void InitializePageGuardViolation(X64Context* thread_context, uint64_t fault_address) {
+    code_ = Code::kPageGuardViolation;
+    thread_context_ = thread_context;
+    fault_address_ = fault_address;
   }
 
   Code code() const { return code_; }

--- a/src/xenia/base/exception_handler_win.cc
+++ b/src/xenia/base/exception_handler_win.cc
@@ -55,6 +55,10 @@ LONG CALLBACK ExceptionHandlerCallback(PEXCEPTION_POINTERS ex_info) {
       ex.InitializeAccessViolation(
           &thread_context, ex_info->ExceptionRecord->ExceptionInformation[1]);
       break;
+    case STATUS_GUARD_PAGE_VIOLATION:
+      ex.InitializePageGuardViolation(
+          &thread_context, ex_info->ExceptionRecord->ExceptionInformation[1]);
+      break;
     default:
       // Unknown/unhandled type.
       return EXCEPTION_CONTINUE_SEARCH;

--- a/src/xenia/base/memory.h
+++ b/src/xenia/base/memory.h
@@ -28,11 +28,14 @@ size_t page_size();
 // This is likely 64KiB.
 size_t allocation_granularity();
 
-enum class PageAccess {
+enum PageAccess {
   kNoAccess = 0,
   kReadOnly = 1 << 0,
   kReadWrite = kReadOnly | 1 << 1,
   kExecuteReadWrite = kReadWrite | 1 << 2,
+  kGuardPage = 1 << 3,
+
+  kGuardReadWrite = kGuardPage | kReadWrite,
 };
 
 enum class AllocationType {

--- a/src/xenia/base/memory_win.cc
+++ b/src/xenia/base/memory_win.cc
@@ -35,19 +35,33 @@ size_t allocation_granularity() {
 }
 
 DWORD ToWin32ProtectFlags(PageAccess access) {
+  DWORD flags = 0;
+  if (access & PageAccess::kGuardPage) {
+    flags |= PAGE_GUARD;
+
+    access = static_cast<PageAccess>(access & ~PageAccess::kGuardPage);
+  }
+
   switch (access) {
     case PageAccess::kNoAccess:
-      return PAGE_NOACCESS;
+      flags |= PAGE_NOACCESS;
+      break;
     case PageAccess::kReadOnly:
-      return PAGE_READONLY;
+      flags |= PAGE_READONLY;
+      break;
     case PageAccess::kReadWrite:
-      return PAGE_READWRITE;
+      flags |= PAGE_READWRITE;
+      break;
     case PageAccess::kExecuteReadWrite:
-      return PAGE_EXECUTE_READWRITE;
+      flags |= PAGE_EXECUTE_READWRITE;
+      break;
     default:
       assert_unhandled_case(access);
-      return PAGE_NOACCESS;
+      flags |= PAGE_NOACCESS;
+      break;
   }
+
+  return flags;
 }
 
 void* AllocFixed(void* base_address, size_t length,

--- a/src/xenia/cpu/mmio_handler.cc
+++ b/src/xenia/cpu/mmio_handler.cc
@@ -170,6 +170,9 @@ bool MMIOHandler::CheckWriteWatch(X64Context* thread_context,
         entry->address + entry->length > physical_address) {
       // Hit!
       pending_invalidates.push_back(entry);
+      // TODO(benvanik): outside of lock?
+      ClearWriteWatch(entry);
+
       it = write_watches_.erase(it);
       continue;
     }

--- a/src/xenia/cpu/mmio_handler.cc
+++ b/src/xenia/cpu/mmio_handler.cc
@@ -116,33 +116,27 @@ uintptr_t MMIOHandler::AddPhysicalWriteWatch(uint32_t guest_address,
   global_critical_region_.mutex().unlock();
 
   // Make the desired range read only under all address spaces.
-  xe::memory::Protect(physical_membase_ + entry->address, entry->length,
-                      xe::memory::PageAccess::kReadOnly, nullptr);
-  xe::memory::Protect(virtual_membase_ + 0xA0000000 + entry->address,
-                      entry->length, xe::memory::PageAccess::kReadOnly,
-                      nullptr);
-  xe::memory::Protect(virtual_membase_ + 0xC0000000 + entry->address,
-                      entry->length, xe::memory::PageAccess::kReadOnly,
-                      nullptr);
-  xe::memory::Protect(virtual_membase_ + 0xE0000000 + entry->address,
-                      entry->length, xe::memory::PageAccess::kReadOnly,
-                      nullptr);
+  memory::Protect(physical_membase_ + entry->address, entry->length,
+                  memory::PageAccess::kGuardReadWrite, nullptr);
+  memory::Protect(virtual_membase_ + 0xA0000000 + entry->address, entry->length,
+                  memory::PageAccess::kGuardReadWrite, nullptr);
+  memory::Protect(virtual_membase_ + 0xC0000000 + entry->address, entry->length,
+                  memory::PageAccess::kGuardReadWrite, nullptr);
+  memory::Protect(virtual_membase_ + 0xE0000000 + entry->address, entry->length,
+                  memory::PageAccess::kGuardReadWrite, nullptr);
 
   return reinterpret_cast<uintptr_t>(entry);
 }
 
 void MMIOHandler::ClearWriteWatch(WriteWatchEntry* entry) {
-  xe::memory::Protect(physical_membase_ + entry->address, entry->length,
-                      xe::memory::PageAccess::kReadWrite, nullptr);
-  xe::memory::Protect(virtual_membase_ + 0xA0000000 + entry->address,
-                      entry->length, xe::memory::PageAccess::kReadWrite,
-                      nullptr);
-  xe::memory::Protect(virtual_membase_ + 0xC0000000 + entry->address,
-                      entry->length, xe::memory::PageAccess::kReadWrite,
-                      nullptr);
-  xe::memory::Protect(virtual_membase_ + 0xE0000000 + entry->address,
-                      entry->length, xe::memory::PageAccess::kReadWrite,
-                      nullptr);
+  memory::Protect(physical_membase_ + entry->address, entry->length,
+                  xe::memory::PageAccess::kReadWrite, nullptr);
+  memory::Protect(virtual_membase_ + 0xA0000000 + entry->address, entry->length,
+                  xe::memory::PageAccess::kReadWrite, nullptr);
+  memory::Protect(virtual_membase_ + 0xC0000000 + entry->address, entry->length,
+                  xe::memory::PageAccess::kReadWrite, nullptr);
+  memory::Protect(virtual_membase_ + 0xE0000000 + entry->address, entry->length,
+                  xe::memory::PageAccess::kReadWrite, nullptr);
 }
 
 void MMIOHandler::CancelWriteWatch(uintptr_t watch_handle) {
@@ -176,13 +170,10 @@ bool MMIOHandler::CheckWriteWatch(X64Context* thread_context,
         entry->address + entry->length > physical_address) {
       // Hit!
       pending_invalidates.push_back(entry);
-      // TODO(benvanik): outside of lock?
-      ClearWriteWatch(entry);
-      auto erase_it = it;
-      ++it;
-      write_watches_.erase(erase_it);
+      it = write_watches_.erase(it);
       continue;
     }
+
     ++it;
   }
   global_critical_region_.mutex().unlock();
@@ -190,6 +181,7 @@ bool MMIOHandler::CheckWriteWatch(X64Context* thread_context,
     // Rethrow access violation - range was not being watched.
     return false;
   }
+
   while (!pending_invalidates.empty()) {
     auto entry = pending_invalidates.back();
     pending_invalidates.pop_back();
@@ -197,6 +189,7 @@ bool MMIOHandler::CheckWriteWatch(X64Context* thread_context,
                     physical_address);
     delete entry;
   }
+
   // Range was watched, so lets eat this access violation.
   return true;
 }
@@ -366,7 +359,8 @@ bool MMIOHandler::ExceptionCallbackThunk(Exception* ex, void* data) {
 }
 
 bool MMIOHandler::ExceptionCallback(Exception* ex) {
-  if (ex->code() != Exception::Code::kAccessViolation) {
+  if (ex->code() != Exception::Code::kAccessViolation &&
+      ex->code() != Exception::Code::kPageGuardViolation) {
     return false;
   }
   if (ex->fault_address() < uint64_t(virtual_membase_) ||


### PR DESCRIPTION
* Should fix BF1943 and other games that spam textures into memory.