### PR TITLE
Fixed mtcrf which was wrongly implemented as mtcr

### DIFF
--- a/src/xenia/cpu/frontend/ppc_emit_control.cc
+++ b/src/xenia/cpu/frontend/ppc_emit_control.cc
@@ -655,7 +655,13 @@ XEEMITTER(mtcrf, 0x7C000120, XFX)(PPCHIRBuilder& f, InstrData& i) {
       f.StoreCR(f.LoadZeroInt64());
     }
   } else {
-    f.StoreCR(v);
+    uint32_t bits = (i.XFX.spr & 0x1FF) >> 1;
+    for (int b = 0; b <= 7; ++b) {
+      if (bits & (1 << b)) {
+        int cri = 7 - b;
+        f.StoreCR(cri, v);
+      }
+    }
   }
   return 0;
 }


### PR DESCRIPTION
While the instruction `mtocrf` only allows to update one CR field at a time, the instruction `mtcrf` allows a subset of CR fields to be updated. However, Xenia's implementation of `mtcrf` updates all fields, ignoring the `FXM` instruction code. Only `mtcr rS` (simplified mnemonic for `mtcrf 0xFF, rS`) does that.

PS: See page 130 in the [Power ISA docs](https://www.power.org/wp-content/uploads/2012/07/PowerISA_V2.06B_V2_PUBLIC.pdf).
PSS: Since this is a small change, I haven't bothered to build Xenia, let alone running tests before submitting this PR.