### PR TITLE
Texture Invalidation Fix

### DIFF
--- a/src/xenia/cpu/mmio_handler.h
+++ b/src/xenia/cpu/mmio_handler.h
@@ -63,6 +63,7 @@ class MMIOHandler {
                                   WriteWatchCallback callback,
                                   void* callback_context, void* callback_data);
   void CancelWriteWatch(uintptr_t watch_handle);
+  void InvalidateRange(uint32_t physical_address, size_t length);
 
  protected:
   struct WriteWatchEntry {
@@ -83,7 +84,7 @@ class MMIOHandler {
   bool ExceptionCallback(Exception* ex);
 
   void ClearWriteWatch(WriteWatchEntry* entry);
-  bool CheckWriteWatch(X64Context* thread_context, uint64_t fault_address);
+  bool CheckWriteWatch(uint64_t fault_address);
 
   uint8_t* virtual_membase_;
   uint8_t* physical_membase_;


### PR DESCRIPTION
* Fixes: *Everything*
 * Games were freeing texture memory and then reallocating texture memory in the same spot, which neutered the MMIO Handler's watching capabilities. We now purge the entry when the memory is freed or its access protection is changed.