### PR TITLE
Partially implement XamUserWriteProfileSettings

### DIFF
--- a/src/xenia/kernel/xam/user_profile.cc
+++ b/src/xenia/kernel/xam/user_profile.cc
@@ -86,8 +86,22 @@ UserProfile::UserProfile() {
 }
 
 void UserProfile::AddSetting(std::unique_ptr<Setting> setting) {
-  settings_.insert({setting->setting_id, setting.get()});
-  setting_list_.push_back(std::move(setting));
+  Setting* previous_setting = setting.get();
+  std::swap(settings_[setting->setting_id], previous_setting);
+
+  if (previous_setting) {
+    // replace: swap out the old setting from the owning list
+    for (auto vec_it = setting_list_.begin(); vec_it != setting_list_.end();
+         ++vec_it) {
+      if (vec_it->get() == previous_setting) {
+        vec_it->swap(setting);
+        break;
+      }
+    }
+  } else {
+    // new setting: add to the owning list
+    setting_list_.push_back(std::move(setting));
+  }
 }
 
 UserProfile::Setting* UserProfile::GetSetting(uint32_t setting_id) {


### PR DESCRIPTION
Handles writing binary blob settings to the user profile which can then be read
by XamUserReadProfileSettings.

This allows the game "Legend of Spyro: Dawn of the Dragon" to proceed past its "press start" screen. It would otherwise sit in an infinite loop calling XamUserWriteProfileSettings to write some config data and XamUserReadProfileSettings to verify the write.

The implementation is definitely not complete since it's based on observing the behaviour of only one game. That game only writes the BINARY type, so I wasn't able to deduce the format of any of the other datatypes from the structs that it passes to this function.