### PR TITLE
Implemented REG_TO_MEM GPU opcode

### DIFF
--- a/src/xenia/gpu/command_processor.h
+++ b/src/xenia/gpu/command_processor.h
@@ -136,6 +136,8 @@ class CommandProcessor {
                                        uint32_t packet, uint32_t count);
   bool ExecutePacketType3_REG_RMW(RingbufferReader* reader, uint32_t packet,
                                   uint32_t count);
+  bool ExecutePacketType3_REG_TO_MEM(RingbufferReader* reader, uint32_t packet,
+                                      uint32_t count);
   bool ExecutePacketType3_COND_WRITE(RingbufferReader* reader, uint32_t packet,
                                      uint32_t count);
   bool ExecutePacketType3_EVENT_WRITE(RingbufferReader* reader, uint32_t packet,


### PR DESCRIPTION
I've added this opcode based upon what I assume is the proper implementation of it assuming it's name is a proper descriptor of what it does.

Arguments should be a register and a memory address. Swapping the arguments throws an out of range exception on the register side.

I've been sitting on this for a while, just figured that it might be the proper implementation. I could be totally wrong however.