### PR TITLE
Trace Viewer UI Improvements

### DIFF
--- a/src/xenia/gpu/trace_player.cc
+++ b/src/xenia/gpu/trace_player.cc
@@ -92,16 +92,17 @@ void TracePlayer::PlayTraceOnThread(const uint8_t* trace_data,
   auto command_processor = graphics_system_->command_processor();
 
   command_processor->set_swap_mode(SwapMode::kIgnored);
-  player_start_ptr_ = trace_data;
-  player_target_ptr_ = trace_data + trace_size;
-  player_current_ptr_ = trace_data;
+  playback_percent_ = 0;
+  auto trace_end = trace_data + trace_size;
 
   playing_trace_ = true;
   auto trace_ptr = trace_data;
   bool pending_break = false;
   const PacketStartCommand* pending_packet = nullptr;
   while (trace_ptr < trace_data + trace_size) {
-    player_current_ptr_ = trace_ptr;
+    playback_percent_ = uint32_t(
+        (float(trace_ptr - trace_data) / float(trace_end - trace_data)) *
+        10000);
 
     auto type = static_cast<TraceCommandType>(xe::load<uint32_t>(trace_ptr));
     switch (type) {

--- a/src/xenia/gpu/trace_player.cc
+++ b/src/xenia/gpu/trace_player.cc
@@ -64,9 +64,9 @@ void TracePlayer::SeekCommand(int target_command) {
   auto frame = current_frame();
   const auto& command = frame->commands[target_command];
   assert_true(frame->start_ptr <= command.end_ptr);
-  if (target_command && previous_command_index == target_command - 1) {
+  if (previous_command_index != -1 && target_command > previous_command_index) {
     // Seek forward.
-    const auto& previous_command = frame->commands[target_command - 1];
+    const auto& previous_command = frame->commands[previous_command_index];
     PlayTrace(previous_command.end_ptr,
               command.end_ptr - previous_command.end_ptr,
               TracePlaybackMode::kBreakOnSwap);

--- a/src/xenia/gpu/trace_player.cc
+++ b/src/xenia/gpu/trace_player.cc
@@ -92,11 +92,17 @@ void TracePlayer::PlayTraceOnThread(const uint8_t* trace_data,
   auto command_processor = graphics_system_->command_processor();
 
   command_processor->set_swap_mode(SwapMode::kIgnored);
+  player_start_ptr_ = trace_data;
+  player_target_ptr_ = trace_data + trace_size;
+  player_current_ptr_ = trace_data;
 
+  playing_trace_ = true;
   auto trace_ptr = trace_data;
   bool pending_break = false;
   const PacketStartCommand* pending_packet = nullptr;
   while (trace_ptr < trace_data + trace_size) {
+    player_current_ptr_ = trace_ptr;
+
     auto type = static_cast<TraceCommandType>(xe::load<uint32_t>(trace_ptr));
     switch (type) {
       case TraceCommandType::kPrimaryBufferStart: {
@@ -184,6 +190,7 @@ void TracePlayer::PlayTraceOnThread(const uint8_t* trace_data,
     }
   }
 
+  playing_trace_ = false;
   command_processor->set_swap_mode(SwapMode::kNormal);
   command_processor->IssueSwap(0, 1280, 720);
 }

--- a/src/xenia/gpu/trace_player.h
+++ b/src/xenia/gpu/trace_player.h
@@ -10,6 +10,7 @@
 #ifndef XENIA_GPU_TRACE_PLAYER_H_
 #define XENIA_GPU_TRACE_PLAYER_H_
 
+#include <atomic>
 #include <string>
 
 #include "xenia/gpu/trace_protocol.h"
@@ -34,7 +35,13 @@ class TracePlayer : public TraceReader {
   GraphicsSystem* graphics_system() const { return graphics_system_; }
   int current_frame_index() const { return current_frame_index_; }
   int current_command_index() const { return current_command_index_; }
+  bool playing_trace() const { return playing_trace_; }
   const Frame* current_frame() const;
+
+  // Only valid if playing_trace is true.
+  const uint8_t* player_current_ptr() const { return player_current_ptr_; }
+  const uint8_t* player_start_ptr() const { return player_start_ptr_; }
+  const uint8_t* player_target_ptr() const { return player_target_ptr_; }
 
   void SeekFrame(int target_frame);
   void SeekCommand(int target_command);
@@ -49,6 +56,10 @@ class TracePlayer : public TraceReader {
   GraphicsSystem* graphics_system_;
   int current_frame_index_;
   int current_command_index_;
+  std::atomic<bool> playing_trace_ = false;
+  std::atomic<const uint8_t*> player_current_ptr_ = 0;
+  std::atomic<const uint8_t*> player_start_ptr_ = 0;
+  std::atomic<const uint8_t*> player_target_ptr_ = 0;
 };
 
 }  // namespace gpu

--- a/src/xenia/gpu/trace_player.h
+++ b/src/xenia/gpu/trace_player.h
@@ -39,9 +39,8 @@ class TracePlayer : public TraceReader {
   const Frame* current_frame() const;
 
   // Only valid if playing_trace is true.
-  const uint8_t* player_current_ptr() const { return player_current_ptr_; }
-  const uint8_t* player_start_ptr() const { return player_start_ptr_; }
-  const uint8_t* player_target_ptr() const { return player_target_ptr_; }
+  // Scalar from 0-10000
+  uint32_t playback_percent() const { return playback_percent_; }
 
   void SeekFrame(int target_frame);
   void SeekCommand(int target_command);
@@ -56,10 +55,8 @@ class TracePlayer : public TraceReader {
   GraphicsSystem* graphics_system_;
   int current_frame_index_;
   int current_command_index_;
-  std::atomic<bool> playing_trace_ = false;
-  std::atomic<const uint8_t*> player_current_ptr_ = 0;
-  std::atomic<const uint8_t*> player_start_ptr_ = 0;
-  std::atomic<const uint8_t*> player_target_ptr_ = 0;
+  bool playing_trace_ = false;
+  std::atomic<uint32_t> playback_percent_ = 0;
 };
 
 }  // namespace gpu

--- a/src/xenia/gpu/trace_viewer.cc
+++ b/src/xenia/gpu/trace_viewer.cc
@@ -615,8 +615,8 @@ void TraceViewer::DrawTextureInfo(const Shader::SamplerDesc& desc) {
       ImGui::Text("Cube: ?");
       break;
   }
-  static const char* swizzle_map[] = {"Red", "Green", "Blue", "Alpha", "Zero",
-                                      "One", "UNK6",  "UNK7"};
+  static const char* swizzle_map[] = {"Red",  "Green", "Blue", "Alpha",
+                                      "Zero", "One",   "UNK6", "UNK7"};
   ImGui::Text("Swizzle: %s %s %s %s",
               swizzle_map[(texture_info.swizzle >> 0) & 0x7],
               swizzle_map[(texture_info.swizzle >> 3) & 0x7],

--- a/src/xenia/gpu/trace_viewer.cc
+++ b/src/xenia/gpu/trace_viewer.cc
@@ -583,6 +583,7 @@ void TraceViewer::DrawTextureInfo(const Shader::SamplerDesc& desc) {
   }
   ImGui::NextColumn();
   ImGui::Text("Fetch Slot: %d", desc.fetch_slot);
+  ImGui::Text("Guest Address: %.8X", texture_info.guest_address);
   switch (texture_info.dimension) {
     case Dimension::k1D:
       ImGui::Text("1D: %dpx", texture_info.width + 1);
@@ -599,6 +600,14 @@ void TraceViewer::DrawTextureInfo(const Shader::SamplerDesc& desc) {
       ImGui::Text("Cube: ?");
       break;
   }
+  static const char* swizzle_map[] = {"Red", "Green", "Blue", "Alpha", "Zero",
+                                      "One", "UNK6",  "UNK7"};
+  ImGui::Text("Swizzle: %s %s %s %s",
+              swizzle_map[(texture_info.swizzle >> 0) & 0x7],
+              swizzle_map[(texture_info.swizzle >> 3) & 0x7],
+              swizzle_map[(texture_info.swizzle >> 6) & 0x7],
+              swizzle_map[(texture_info.swizzle >> 9) & 0x7]);
+
   ImGui::Columns(1);
 }
 

--- a/src/xenia/gpu/trace_viewer.cc
+++ b/src/xenia/gpu/trace_viewer.cc
@@ -947,16 +947,9 @@ void TraceViewer::DrawStateUI() {
 
   if (player_->playing_trace()) {
     ImGui::Text("Playing trace...");
-    uint64_t start = uint64_t(player_->player_start_ptr());
-    uint64_t end = uint64_t(player_->player_target_ptr());
-    uint64_t cur = uint64_t(player_->player_current_ptr());
-
-    uint64_t rel_cur = cur - start;
-    uint64_t rel_end = end - start;
-
     float width = ImGui::GetWindowWidth() - 20.f;
 
-    ProgressBar((float)rel_cur / (float)rel_end, width);
+    ProgressBar(float(player_->playback_percent()) / 10000.f, width);
     ImGui::End();
     return;
   }

--- a/src/xenia/gpu/trace_viewer.cc
+++ b/src/xenia/gpu/trace_viewer.cc
@@ -1473,7 +1473,6 @@ void TraceViewer::DrawStateUI() {
   }
   if (ImGui::CollapsingHeader("Fetch Constants (raw)")) {
     ImGui::Columns(2);
-    ImGui::SetColumnOffset(1, 85.0f);
     for (int i = XE_GPU_REG_SHADER_CONSTANT_FETCH_00_0;
          i <= XE_GPU_REG_SHADER_CONSTANT_FETCH_31_5; ++i) {
       ImGui::Text("f%02d_%d", (i - XE_GPU_REG_SHADER_CONSTANT_FETCH_00_0) / 6,

--- a/src/xenia/gpu/trace_viewer.cc
+++ b/src/xenia/gpu/trace_viewer.cc
@@ -192,9 +192,16 @@ void TraceViewer::DrawControllerUI() {
   if (ImGui::IsItemHovered()) {
     ImGui::SetTooltip("Skip to last frame");
   }
+  if (player_->playing_trace()) {
+    // Don't allow the user to change the frame index just yet...
+    // TODO: Find a way to disable the slider below.
+    target_frame = player_->current_frame_index();
+  }
+
   ImGui::SameLine();
   ImGui::SliderInt("", &target_frame, 0, player_->frame_count() - 1);
-  if (target_frame != player_->current_frame_index()) {
+  if (target_frame != player_->current_frame_index() &&
+      !player_->playing_trace()) {
     player_->SeekFrame(target_frame);
   }
   ImGui::End();

--- a/src/xenia/gpu/trace_viewer.cc
+++ b/src/xenia/gpu/trace_viewer.cc
@@ -398,10 +398,18 @@ void TraceViewer::DrawCommandListUI() {
   if (ImGui::IsItemHovered()) {
     ImGui::SetTooltip("Move to the last command");
   }
+  if (player_->playing_trace()) {
+    // Don't allow the user to change the command index just yet...
+    // TODO: Find a way to disable the slider below.
+    target_command = player_->current_command_index();
+  }
+
   ImGui::PushItemWidth(float(column_width - 15));
   ImGui::SliderInt("", &target_command, -1, command_count - 1);
   ImGui::PopItemWidth();
-  if (target_command != player_->current_command_index()) {
+
+  if (target_command != player_->current_command_index() &&
+      !player_->playing_trace()) {
     did_seek = true;
     player_->SeekCommand(target_command);
   }


### PR DESCRIPTION
* Allow seeking forward more than one frame (without playing from the beginning)
* Progress bar while seeking
 * Fixes crash with texture view open while seeking (masks it really - but that should be fine. See https://github.com/benvanik/xenia/commit/7a1d7bd652c1fc5d533a7e4cb532003fa141efe5)
* Disable command list and frame list UI while playing back a trace (to avoid queuing up a crapload of commands)