### PR TITLE
VS2015 Update 1 fix + GLContext small cleanup

### DIFF
--- a/src/xenia/debug/ui/debug_window.cc
+++ b/src/xenia/debug/ui/debug_window.cc
@@ -1245,13 +1245,13 @@ void DebugWindow::DrawBreakpointsPane() {
       if (has_any_call_filter && !call_rankings[i].second) {
         continue;
       }
-      auto export = all_exports[call_rankings[i].first];
-      if (export->type != cpu::Export::Type::kFunction ||
-          !export->is_implemented()) {
+      auto export_entry = all_exports[call_rankings[i].first];
+      if (export_entry->type != cpu::Export::Type::kFunction ||
+          !export_entry->is_implemented()) {
         continue;
       }
       // TODO(benvanik): skip unused kernel calls.
-      ImGui::PushID(export);
+      ImGui::PushID(export_entry);
       // TODO(benvanik): selection, hover info (module name, ordinal, etc).
       bool is_pre_enabled = false;
       bool is_post_enabled = false;
@@ -1275,7 +1275,7 @@ void DebugWindow::DrawBreakpointsPane() {
       ImGui::SameLine();
       ImGui::Dummy(ImVec2(4, 0));
       ImGui::SameLine();
-      ImGui::Text(export->name);
+      ImGui::Text(export_entry->name);
       ImGui::Dummy(ImVec2(0, 1));
       ImGui::PopID();
     }

--- a/src/xenia/ui/gl/gl_context.cc
+++ b/src/xenia/ui/gl/gl_context.cc
@@ -463,7 +463,7 @@ void GLContext::BeginSwap() {
 
 void GLContext::EndSwap() {
   SCOPE_profile_cpu_i("gpu", "xe::ui::gl::GLContext::EndSwap");
-  SwapBuffers(dc());
+  SwapBuffers(dc_);
 }
 
 }  // namespace gl

--- a/src/xenia/ui/gl/gl_context.h
+++ b/src/xenia/ui/gl/gl_context.h
@@ -35,8 +35,6 @@ class GLContext : public GraphicsContext {
  public:
   ~GLContext() override;
 
-  HDC dc() const { return dc_; }
-
   ImmediateDrawer* immediate_drawer() override;
 
   bool is_current() override;


### PR DESCRIPTION
Installed VS2015U1, fixed compilation. Similar fix to commit 08ae855.

Also, dc_ can be used directly right? Is the dc() function a relic of some older and deleted code? Anyway, I removed it.

Thanks!