### PR TITLE
Compiler fixes

### DIFF
--- a/src/xenia/cpu/compiler/passes/constant_propagation_pass.cc
+++ b/src/xenia/cpu/compiler/passes/constant_propagation_pass.cc
@@ -157,7 +157,7 @@ bool ConstantPropagationPass::Run(HIRBuilder* builder) {
           if (i->src1.value->IsConstant()) {
             TypeName target_type = v->type;
             v->set_from(i->src1.value);
-            v->Convert(target_type, ROUND_TO_NEAREST);
+            v->Convert(target_type, RoundMode(i->flags));
             i->Remove();
           }
           break;

--- a/src/xenia/cpu/compiler/passes/constant_propagation_pass.cc
+++ b/src/xenia/cpu/compiler/passes/constant_propagation_pass.cc
@@ -197,8 +197,8 @@ bool ConstantPropagationPass::Run(HIRBuilder* builder) {
                 // Memory is readonly - can just return the value.
                 switch (v->type) {
                   case INT32_TYPE:
-                    v->set_constant(xe::load_and_swap<uint32_t>(
-                        memory->TranslateVirtual(address)));
+                    v->set_constant(
+                        xe::load<uint32_t>(memory->TranslateVirtual(address)));
                     i->Remove();
                     break;
                   default:

--- a/src/xenia/cpu/hir/value.cc
+++ b/src/xenia/cpu/hir/value.cc
@@ -77,8 +77,8 @@ uint64_t Value::AsUint64() {
 }
 
 void Value::Cast(TypeName target_type) {
-  // TODO(benvanik): big matrix.
-  assert_always();
+  // Only need a type change.
+  type = target_type;
 }
 
 void Value::ZeroExtend(TypeName target_type) {
@@ -199,8 +199,25 @@ void Value::Truncate(TypeName target_type) {
 }
 
 void Value::Convert(TypeName target_type, RoundMode round_mode) {
-  // TODO(benvanik): big matrix.
-  assert_always();
+  switch (type) {
+    case FLOAT32_TYPE:
+      switch (target_type) {
+        case FLOAT64_TYPE:
+          type = target_type;
+          constant.f64 = constant.f32;
+          return;
+      }
+    case FLOAT64_TYPE:
+      switch (target_type) {
+        case FLOAT32_TYPE:
+          type = target_type;
+          constant.f32 = (float)constant.f64;
+          return;
+      }
+    default:
+      assert_unhandled_case(target_type);
+      return;
+  }
 }
 
 void Value::Round(RoundMode round_mode) {

--- a/src/xenia/cpu/xex_module.cc
+++ b/src/xenia/cpu/xex_module.cc
@@ -281,6 +281,34 @@ bool XexModule::Load(const std::string& name, const std::string& path,
     }
   }
 
+  // Setup memory protection.
+  // TODO: This introduces a load of constants into the JIT, and Xenia isn't
+  // quite set-up to handle constants yet...
+  /*
+  auto sec_header = xex_security_info();
+  auto heap = memory()->LookupHeap(sec_header->load_address);
+  auto page_size = heap->page_size();
+  for (uint32_t i = 0, page = 0; i < sec_header->page_descriptor_count; i++) {
+    // Byteswap the bitfield manually.
+    xex2_page_descriptor desc;
+    desc.value = xe::byte_swap(sec_header->page_descriptors[i].value);
+
+    auto address = sec_header->load_address + (page * page_size);
+    auto size = desc.size * page_size;
+    switch (desc.info) {
+    case XEX_SECTION_CODE:
+    case XEX_SECTION_READONLY_DATA:
+      heap->Protect(address, size, kMemoryProtectRead);
+      break;
+    case XEX_SECTION_DATA:
+      heap->Protect(address, size, kMemoryProtectRead | kMemoryProtectWrite);
+      break;
+    }
+
+    page += desc.size;
+  }
+  */
+
   return true;
 }
 


### PR DESCRIPTION
* Fix double-swapping in OPCODE_LOAD
* Add code to enforce page protections (but commented because it introduces a load of constants)