### PR TITLE
Fix compilation error of translated GLSL shader.

### DIFF
--- a/src/xenia/gpu/glsl_shader_translator.cc
+++ b/src/xenia/gpu/glsl_shader_translator.cc
@@ -502,7 +502,7 @@ void GlslShaderTranslator::ProcessTextureFetchInstruction(
     case FetchOpcode::kTextureFetch:
       switch (instr.dimension) {
         case TextureDimension::k1D:
-          EmitSourceDepth("if (state.texture_samplers[%d] != 0) {\n",
+          EmitSourceDepth("if (state.texture_samplers[%d] != uvec2(0)) {\n",
                           instr.operands[1].storage_index);
           EmitSourceDepth(
               "  pv = texture(sampler1D(state.texture_samplers[%d]), "
@@ -513,7 +513,7 @@ void GlslShaderTranslator::ProcessTextureFetchInstruction(
           EmitSourceDepth("}\n");
           break;
         case TextureDimension::k2D:
-          EmitSourceDepth("if (state.texture_samplers[%d] != 0) {\n",
+          EmitSourceDepth("if (state.texture_samplers[%d] != uvec2(0)) {\n",
                           instr.operands[1].storage_index);
           EmitSourceDepth(
               "  pv = texture(sampler2D(state.texture_samplers[%d]), "
@@ -524,7 +524,7 @@ void GlslShaderTranslator::ProcessTextureFetchInstruction(
           EmitSourceDepth("}\n");
           break;
         case TextureDimension::k3D:
-          EmitSourceDepth("if (state.texture_samplers[%d] != 0) {\n",
+          EmitSourceDepth("if (state.texture_samplers[%d] != uvec2(0)) {\n",
                           instr.operands[1].storage_index);
           EmitSourceDepth(
               "  pv = texture(sampler3D(state.texture_samplers[%d]), "
@@ -536,7 +536,7 @@ void GlslShaderTranslator::ProcessTextureFetchInstruction(
           break;
         case TextureDimension::kCube:
           // TODO(benvanik): undo CUBEv logic on t? (s,t,faceid)
-          EmitSourceDepth("if (state.texture_samplers[%d] != 0) {\n",
+          EmitSourceDepth("if (state.texture_samplers[%d] != uvec2(0)) {\n",
                           instr.operands[1].storage_index);
           EmitSourceDepth(
               "  pv = texture(samplerCube(state.texture_samplers[%d]), "


### PR DESCRIPTION
Comparison of uvec2 and int is not possible, explicitly
use a zero-value uvec2.

Error from logs:
```
!> 00000004 Unable to link program: 
Shader Compile Log:
Fragment shader failed to compile with the following errors:
ERROR: 0:125: error(#162) Wrong operand types: no operation "!=" exists that takes a left-hand operand of type "const in highp 2-component vector of uvec2" and a right operand of type "const int" (or there is no acceptable conversion)
ERROR: error(#273) 1 compilation errors.  No code generated
```

Example line: [see line 125 of full shader here](https://gist.github.com/sephiroth99/53b8a9087e8be1bc8424) This example shader is from Forza 2.
```
if (state.texture_samplers[0] != 0) {
```