### PR TITLE
ObjectTable: Remove explicit specialization in class scope

### DIFF
--- a/src/xenia/kernel/util/object_table.cc
+++ b/src/xenia/kernel/util/object_table.cc
@@ -202,6 +202,14 @@ ObjectTable::ObjectTableEntry* ObjectTable::LookupTable(X_HANDLE handle) {
   return nullptr;
 }
 
+// Generic lookup
+template <>
+object_ref<XObject> ObjectTable::LookupObject<XObject>(X_HANDLE handle) {
+  auto object = ObjectTable::LookupObject(handle, false);
+  auto result = object_ref<XObject>(reinterpret_cast<XObject*>(object));
+  return result;
+}
+
 XObject* ObjectTable::LookupObject(X_HANDLE handle, bool already_locked) {
   handle = TranslateHandle(handle);
   if (!handle) {

--- a/src/xenia/kernel/util/object_table.h
+++ b/src/xenia/kernel/util/object_table.h
@@ -46,14 +46,6 @@ class ObjectTable {
     return result;
   }
 
-  // Generic lookup
-  template <>
-  object_ref<XObject> LookupObject<XObject>(X_HANDLE handle) {
-    auto object = LookupObject(handle, false);
-    auto result = object_ref<XObject>(reinterpret_cast<XObject*>(object));
-    return result;
-  }
-
   X_STATUS AddNameMapping(const std::string& name, X_HANDLE handle);
   void RemoveNameMapping(const std::string& name);
   X_STATUS GetObjectByName(const std::string& name, X_HANDLE* out_handle);
@@ -85,6 +77,10 @@ class ObjectTable {
   uint32_t last_free_entry_ = 0;
   std::unordered_map<std::string, X_HANDLE> name_table_;
 };
+
+// Generic lookup
+template <>
+object_ref<XObject> ObjectTable::LookupObject<XObject>(X_HANDLE handle);
 
 }  // namespace util
 }  // namespace kernel


### PR DESCRIPTION
Function template 'LookupObject' in ObjectTable class has
a specialization in class scope, which is not allowed.

While MSVC seems OK with that, clang complains about it.

Fix this issue by moving the definition of the specialisation
outside the class scope, and moving the declaration in the
'.cc' file.

See previous discussion in #482.