### PR TITLE
GL Backend Changes/Fixes

### DIFF
--- a/src/xenia/gpu/gl4/gl4_command_processor.cc
+++ b/src/xenia/gpu/gl4/gl4_command_processor.cc
@@ -396,19 +396,24 @@ void GL4CommandProcessor::PerformSwap(uint32_t frontbuffer_ptr,
   // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   // HACK: just use whatever our current framebuffer is.
   GLuint framebuffer_texture = last_framebuffer_texture_;
-  /*GLuint framebuffer_texture = active_framebuffer_
-                                        ? active_framebuffer_->color_targets[0]
-                                        : last_framebuffer_texture_;*/
+
+  if (last_framebuffer_texture_ == 0) {
+    framebuffer_texture =
+        active_framebuffer_ ? active_framebuffer_->color_targets[0] : 0;
+  }
 
   // Copy the the given framebuffer to the current backbuffer.
   Rect2D src_rect(0, 0, frontbuffer_width ? frontbuffer_width : 1280,
                   frontbuffer_height ? frontbuffer_height : 720);
   Rect2D dest_rect(0, 0, swap_state_.width, swap_state_.height);
-  reinterpret_cast<xe::ui::gl::GLContext*>(context_.get())
-      ->blitter()
-      ->CopyColorTexture2D(framebuffer_texture, src_rect,
-                           static_cast<GLuint>(swap_state_.back_buffer_texture),
-                           dest_rect, GL_LINEAR, true);
+  if (framebuffer_texture != 0) {
+    reinterpret_cast<xe::ui::gl::GLContext*>(context_.get())
+        ->blitter()
+        ->CopyColorTexture2D(
+            framebuffer_texture, src_rect,
+            static_cast<GLuint>(swap_state_.back_buffer_texture), dest_rect,
+            GL_LINEAR, true);
+  }
 
   if (FLAGS_draw_all_framebuffers) {
     int32_t offsetx = (1280 - (1280 / 5));

--- a/src/xenia/gpu/gl4/gl4_shader.cc
+++ b/src/xenia/gpu/gl4/gl4_shader.cc
@@ -140,8 +140,11 @@ bool GL4Shader::CompileProgram() {
   GLint log_length = 0;
   glGetProgramiv(program_, GL_INFO_LOG_LENGTH, &log_length);
   std::string info_log;
-  info_log.resize(log_length - 1);
-  glGetProgramInfoLog(program_, log_length, &log_length, &info_log[0]);
+  if (log_length > 0) {
+    info_log.resize(log_length - 1);
+    glGetProgramInfoLog(program_, log_length, &log_length, &info_log[0]);
+  }
+
   if (!info_log.empty()) {
     XELOGD("Shader log: %s", info_log.c_str());
   }

--- a/src/xenia/gpu/gl4/gl4_shader.cc
+++ b/src/xenia/gpu/gl4/gl4_shader.cc
@@ -135,18 +135,21 @@ bool GL4Shader::CompileProgram() {
     return false;
   }
 
+  // Output info log.
+  // log_length includes the null character.
+  GLint log_length = 0;
+  glGetProgramiv(program_, GL_INFO_LOG_LENGTH, &log_length);
+  std::string info_log;
+  info_log.resize(log_length - 1);
+  glGetProgramInfoLog(program_, log_length, &log_length, &info_log[0]);
+  if (!info_log.empty()) {
+    XELOGD("Shader log: %s", info_log.c_str());
+  }
+
   // Get error log, if we failed to link.
   GLint link_status = 0;
   glGetProgramiv(program_, GL_LINK_STATUS, &link_status);
   if (!link_status) {
-    // log_length includes the null character.
-    GLint log_length = 0;
-    glGetProgramiv(program_, GL_INFO_LOG_LENGTH, &log_length);
-    std::string info_log;
-    info_log.resize(log_length - 1);
-    glGetProgramInfoLog(program_, log_length, &log_length,
-                        const_cast<char*>(info_log.data()));
-    XELOGE("Unable to link program: %s", info_log.c_str());
     host_error_log_ = std::move(info_log);
     assert_always("Unable to link generated shader");
     return false;

--- a/src/xenia/gpu/glsl_shader_translator.cc
+++ b/src/xenia/gpu/glsl_shader_translator.cc
@@ -361,10 +361,10 @@ void GlslShaderTranslator::ProcessExecInstructionBegin(
       EmitSourceDepth("{\n");
       break;
     case ParsedExecInstruction::Type::kConditional:
-      EmitSourceDepth("if ((state.bool_consts[%d] & (1 << %d)) == %c) {\n",
+      EmitSourceDepth("if ((state.bool_consts[%d] & (1 << %d)) %c= 0) {\n",
                       instr.bool_constant_index / 32,
                       instr.bool_constant_index % 32,
-                      instr.condition ? '1' : '0');
+                      instr.condition ? '!' : '=');
       break;
     case ParsedExecInstruction::Type::kPredicated:
       EmitSourceDepth("if (%cp0) {\n", instr.condition ? ' ' : '!');
@@ -384,13 +384,13 @@ void GlslShaderTranslator::ProcessExecInstructionBegin(
 
 void GlslShaderTranslator::ProcessExecInstructionEnd(
     const ParsedExecInstruction& instr) {
-  Unindent();
-  EmitSourceDepth("}\n");
   if (instr.is_end) {
     EmitSourceDepth("pc = 0xFFFF;\n");
     EmitSourceDepth("break;\n");
     cf_wrote_pc_ = true;
   }
+  Unindent();
+  EmitSourceDepth("}\n");
 }
 
 void GlslShaderTranslator::ProcessLoopStartInstruction(
@@ -494,10 +494,10 @@ void GlslShaderTranslator::ProcessJumpInstruction(
       EmitSourceDepth("{\n");
       break;
     case ParsedJumpInstruction::Type::kConditional:
-      EmitSourceDepth("if ((state.bool_consts[%d] & (1 << %d)) == %c) {\n",
+      EmitSourceDepth("if ((state.bool_consts[%d] & (1 << %d)) %c= 0) {\n",
                       instr.bool_constant_index / 32,
                       instr.bool_constant_index % 32,
-                      instr.condition ? '1' : '0');
+                      instr.condition ? '!' : '=');
       needs_fallthrough = true;
       break;
     case ParsedJumpInstruction::Type::kPredicated:

--- a/src/xenia/gpu/trace_player.cc
+++ b/src/xenia/gpu/trace_player.cc
@@ -156,6 +156,7 @@ void TracePlayer::PlayTraceOnThread(const uint8_t* trace_data,
           pending_packet = nullptr;
         }
         if (pending_break) {
+          playing_trace_ = false;
           return;
         }
         break;

--- a/src/xenia/ui/gl/blitter.cc
+++ b/src/xenia/ui/gl/blitter.cc
@@ -202,6 +202,8 @@ struct SavedState {
 
 void Blitter::Draw(GLuint src_texture, Rect2D src_rect, Rect2D dest_rect,
                    GLenum filter) {
+  assert_not_zero(src_texture);
+
   glDisable(GL_SCISSOR_TEST);
   glDisable(GL_STENCIL_TEST);
   glDisablei(GL_BLEND, 0);

--- a/src/xenia/ui/gl/gl_context.cc
+++ b/src/xenia/ui/gl/gl_context.cc
@@ -281,6 +281,8 @@ void GLContext::AssertExtensionsPresent() {
         "OpenGL extension ARB_fragment_coord_conventions is required.");
     return;
   }
+
+  ClearCurrent();
 }
 
 void GLContext::DebugMessage(GLenum source, GLenum type, GLuint id,

--- a/src/xenia/ui/gl/gl_context.h
+++ b/src/xenia/ui/gl/gl_context.h
@@ -83,6 +83,7 @@ class GLContext : public GraphicsContext {
   std::unique_ptr<GLImmediateDrawer> immediate_drawer_;
 
   bool context_lost_ = false;
+  bool robust_access_supported_ = false;
 };
 
 }  // namespace gl

--- a/src/xenia/ui/gl/gl_context.h
+++ b/src/xenia/ui/gl/gl_context.h
@@ -40,6 +40,7 @@ class GLContext : public GraphicsContext {
   bool is_current() override;
   bool MakeCurrent() override;
   void ClearCurrent() override;
+  bool WasLost() override;
 
   void BeginSwap() override;
   void EndSwap() override;
@@ -80,6 +81,8 @@ class GLContext : public GraphicsContext {
 
   Blitter blitter_;
   std::unique_ptr<GLImmediateDrawer> immediate_drawer_;
+
+  bool context_lost_ = false;
 };
 
 }  // namespace gl

--- a/src/xenia/ui/graphics_context.h
+++ b/src/xenia/ui/graphics_context.h
@@ -45,6 +45,12 @@ class GraphicsContext {
   virtual bool MakeCurrent() = 0;
   virtual void ClearCurrent() = 0;
 
+  // Returns true if the OS took away our context because we caused a TDR or
+  // some other outstanding error. When this happens, this context, as well as
+  // any other shared contexts are junk.
+  // This context must be made current in order for this call to work properly.
+  virtual bool WasLost() { return false; }
+
   virtual void BeginSwap() = 0;
   virtual void EndSwap() = 0;
 


### PR DESCRIPTION
* Shaders:
 * Fix incorrect compare against bool consts
 * Always output the info log if it isn't empty (for shader warnings)
* GL backend:
 * Setup to allow Xenia to detect a graphics TDR on contexts
 * TODO: Dump the command stream on TDR.
 * Minor: Blitter::Draw asserts if src_texture is 0.