### PR TITLE
Fix various clang compilation issues 

### DIFF
--- a/src/xenia/base/bit_map.h
+++ b/src/xenia/base/bit_map.h
@@ -10,6 +10,7 @@
 #ifndef XENIA_BASE_BIT_MAP_H_
 #define XENIA_BASE_BIT_MAP_H_
 
+#include <cstddef>
 #include <cstdint>
 #include <vector>
 

--- a/src/xenia/base/byte_stream.cc
+++ b/src/xenia/base/byte_stream.cc
@@ -36,4 +36,24 @@ void ByteStream::Write(const uint8_t* buf, size_t len) {
   Advance(len);
 }
 
+template <>
+std::string ByteStream::Read() {
+  std::string str;
+  uint32_t len = Read<uint32_t>();
+  str.resize(len);
+
+  Read(reinterpret_cast<uint8_t*>(&str[0]), len);
+  return str;
+}
+
+template <>
+std::wstring ByteStream::Read() {
+  std::wstring str;
+  uint32_t len = Read<uint32_t>();
+  str.resize(len);
+
+  Read(reinterpret_cast<uint8_t*>(&str[0]), len * 2);
+  return str;
+}
+
 }  // namespace xe

--- a/src/xenia/base/byte_stream.cc
+++ b/src/xenia/base/byte_stream.cc
@@ -9,6 +9,8 @@
 
 #include "xenia/base/byte_stream.h"
 
+#include <cstring>
+
 #include "xenia/base/assert.h"
 
 namespace xe {

--- a/src/xenia/base/byte_stream.h
+++ b/src/xenia/base/byte_stream.h
@@ -46,26 +46,6 @@ class ByteStream {
     return data;
   }
 
-  template <>
-  std::string Read() {
-    std::string str;
-    uint32_t len = Read<uint32_t>();
-    str.resize(len);
-
-    Read(reinterpret_cast<uint8_t*>(&str[0]), len);
-    return str;
-  }
-
-  template <>
-  std::wstring Read() {
-    std::wstring str;
-    uint32_t len = Read<uint32_t>();
-    str.resize(len);
-
-    Read(reinterpret_cast<uint8_t*>(&str[0]), len * 2);
-    return str;
-  }
-
   template <typename T>
   void Write(T data) {
     Write(reinterpret_cast<uint8_t*>(&data), sizeof(T));
@@ -86,6 +66,12 @@ class ByteStream {
   size_t data_length_ = 0;
   size_t offset_ = 0;
 };
+
+template <>
+std::string ByteStream::Read();
+
+template <>
+std::wstring ByteStream::Read();
 
 }  // namespace xe
 

--- a/src/xenia/base/profiling.cc
+++ b/src/xenia/base/profiling.cc
@@ -37,10 +37,8 @@
 #include "third_party/microprofile/microprofileui.h"
 #endif  // XE_OPTION_PROFILING
 
-#if XE_OPTION_PROFILING_UI
 #undef DrawText
 #include "xenia/ui/microprofile_drawer.h"
-#endif  // XE_OPTION_PROFILING_UI
 
 DEFINE_bool(show_profiler, false, "Show profiling UI by default.");
 
@@ -261,7 +259,9 @@ void Profiler::OnMouseDown(bool left_button, bool right_button) {}
 void Profiler::OnMouseUp() {}
 void Profiler::OnMouseMove(int x, int y) {}
 void Profiler::OnMouseWheel(int x, int y, int dy) {}
-void Profiler::set_display(std::unique_ptr<ui::MicroprofilerDrawer> display) {}
+void Profiler::ToggleDisplay() {}
+void Profiler::TogglePause() {}
+void Profiler::set_window(ui::Window* window) {}
 void Profiler::Present() {}
 
 #endif  // XE_OPTION_PROFILING

--- a/src/xenia/cpu/hir/value.cc
+++ b/src/xenia/cpu/hir/value.cc
@@ -206,12 +206,18 @@ void Value::Convert(TypeName target_type, RoundMode round_mode) {
           type = target_type;
           constant.f64 = constant.f32;
           return;
+        default:
+          assert_unhandled_case(target_type);
+          return;
       }
     case FLOAT64_TYPE:
       switch (target_type) {
         case FLOAT32_TYPE:
           type = target_type;
           constant.f32 = (float)constant.f64;
+          return;
+        default:
+          assert_unhandled_case(target_type);
           return;
       }
     default:

--- a/src/xenia/cpu/hir/value.cc
+++ b/src/xenia/cpu/hir/value.cc
@@ -215,7 +215,7 @@ void Value::Convert(TypeName target_type, RoundMode round_mode) {
           return;
       }
     default:
-      assert_unhandled_case(target_type);
+      assert_unhandled_case(type);
       return;
   }
 }

--- a/src/xenia/cpu/processor.cc
+++ b/src/xenia/cpu/processor.cc
@@ -338,7 +338,7 @@ uint64_t Processor::Execute(ThreadState* thread_state, uint32_t address,
   SCOPE_profile_cpu_f("cpu");
 
   auto context = thread_state->context();
-  for (size_t i = 0; i < std::min(arg_count, 8ull); ++i) {
+  for (size_t i = 0; i < std::min(arg_count, static_cast<size_t>(8)); ++i) {
     context->r[3 + i] = args[i];
   }
 

--- a/src/xenia/debug/ui/debug_window.cc
+++ b/src/xenia/debug/ui/debug_window.cc
@@ -318,7 +318,7 @@ void DebugWindow::DrawSourcePane() {
   //   name text box (editable)
   //   combo for interleaved + [ppc, hir, opt hir, x64 + byte with sizes]
   ImGui::AlignFirstTextHeightToWidgets();
-  ImGui::Text(function->module()->name().c_str());
+  ImGui::Text("%s", function->module()->name().c_str());
   ImGui::SameLine();
   ImGui::Dummy(ImVec2(4, 0));
   ImGui::SameLine();
@@ -657,7 +657,7 @@ bool DebugWindow::DrawRegisterTextBox(int id, uint32_t* value) {
     auto alt_value = state_.register_input_hex
                          ? std::to_string(*value)
                          : string_util::to_hex_string(*value);
-    ImGui::SetTooltip(alt_value.c_str());
+    ImGui::SetTooltip("%s", alt_value.c_str());
   }
   return any_changed;
 }
@@ -697,7 +697,7 @@ bool DebugWindow::DrawRegisterTextBox(int id, uint64_t* value) {
     auto alt_value = state_.register_input_hex
                          ? std::to_string(*value)
                          : string_util::to_hex_string(*value);
-    ImGui::SetTooltip(alt_value.c_str());
+    ImGui::SetTooltip("%s", alt_value.c_str());
   }
   return any_changed;
 }
@@ -736,7 +736,7 @@ bool DebugWindow::DrawRegisterTextBox(int id, double* value) {
     auto alt_value = state_.register_input_hex
                          ? std::to_string(*value)
                          : string_util::to_hex_string(*value);
-    ImGui::SetTooltip(alt_value.c_str());
+    ImGui::SetTooltip("%s", alt_value.c_str());
   }
   return any_changed;
 }
@@ -779,7 +779,7 @@ bool DebugWindow::DrawRegisterTextBoxes(int id, float* value) {
       auto alt_value = state_.register_input_hex
                            ? std::to_string(value[i])
                            : string_util::to_hex_string(value[i]);
-      ImGui::SetTooltip(alt_value.c_str());
+      ImGui::SetTooltip("%s", alt_value.c_str());
     }
     if (i < 3) {
       ImGui::SameLine();
@@ -1067,9 +1067,9 @@ void DebugWindow::DrawThreadsPane() {
         ImGui::Dummy(ImVec2(8, 0));
         ImGui::SameLine();
         if (frame.guest_function) {
-          ImGui::Text(frame.guest_function->name().c_str());
+          ImGui::Text("%s", frame.guest_function->name().c_str());
         } else {
-          ImGui::Text(frame.name);
+          ImGui::Text("%s", frame.name);
         }
         if (is_current_thread && !frame.guest_pc) {
           ImGui::PopStyleColor();
@@ -1259,7 +1259,7 @@ void DebugWindow::DrawBreakpointsPane() {
       ImGui::SameLine();
       ImGui::Dummy(ImVec2(4, 0));
       ImGui::SameLine();
-      ImGui::Text(export_entry->name);
+      ImGui::Text("%s", export_entry->name);
       ImGui::Dummy(ImVec2(0, 1));
       ImGui::PopID();
     }

--- a/src/xenia/debug/ui/debug_window.cc
+++ b/src/xenia/debug/ui/debug_window.cc
@@ -715,7 +715,7 @@ bool DebugWindow::DrawRegisterTextBox(int id, double* value) {
   } else {
     input_flags |=
         ImGuiInputTextFlags_CharsDecimal | ImGuiInputTextFlags_AutoSelectAll;
-    std::snprintf(buffer, xe::countof(buffer), "%.8LF", *value);
+    std::snprintf(buffer, xe::countof(buffer), "%.8F", *value);
   }
   char label[16] = {0};
   std::snprintf(label, xe::countof(label), "##dregister%d", id);

--- a/src/xenia/debug/ui/debug_window.cc
+++ b/src/xenia/debug/ui/debug_window.cc
@@ -959,6 +959,8 @@ void DebugWindow::DrawRegistersPane() {
     case RegisterGroup::kHostVector: {
       ImGui::BeginChild("##host_vector");
       for (int i = 0; i < 16; ++i) {
+        float f[4];
+        _mm_storeu_ps(f, thread_info->host_context.xmm_registers[i]);
         auto reg =
             static_cast<X64Register>(static_cast<int>(X64Register::kXmm0) + i);
         ImGui::BeginGroup();
@@ -967,8 +969,7 @@ void DebugWindow::DrawRegistersPane() {
         ImGui::SameLine();
         ImGui::Dummy(ImVec2(4, 0));
         ImGui::SameLine();
-        dirty_host_context |= DrawRegisterTextBoxes(
-            i, thread_info->host_context.xmm_registers[i].m128_f32);
+        dirty_host_context |= DrawRegisterTextBoxes(i, f);
         ImGui::EndGroup();
       }
       ImGui::EndChild();

--- a/src/xenia/debug/ui/debug_window.cc
+++ b/src/xenia/debug/ui/debug_window.cc
@@ -1344,6 +1344,10 @@ void DebugWindow::DrawBreakpointsPane() {
             }
             break;
           }
+          default: {
+            // Ignored.
+            break;
+          }
         }
       }
       if (ImGui::BeginPopupContextItem("##breakpoint_context_menu")) {

--- a/src/xenia/emulator.cc
+++ b/src/xenia/emulator.cc
@@ -504,7 +504,7 @@ X_STATUS Emulator::CompleteLaunch(const std::wstring& path,
     XELOGI("Launching module %s", next_module.c_str());
     auto module = kernel_state_->LoadUserModule(next_module.c_str());
     if (!module) {
-      XELOGE("Failed to load user module %s", path);
+      XELOGE("Failed to load user module %s", path.c_str());
       return X_STATUS_NOT_FOUND;
     }
 

--- a/src/xenia/gpu/glsl_shader_translator.cc
+++ b/src/xenia/gpu/glsl_shader_translator.cc
@@ -559,6 +559,9 @@ void GlslShaderTranslator::ProcessVertexFetchInstruction(
         EmitSource(" = vf%u_%d;\n", instr.operands[1].storage_index,
                    instr.attributes.offset);
         break;
+      default:
+        assert_always();
+        break;
     }
   }
 
@@ -676,6 +679,9 @@ void GlslShaderTranslator::ProcessTextureFetchInstruction(
       EmitUnimplementedTranslationError();
       EmitSourceDepth("pv = vec4(0.0);\n");
       break;
+    case FetchOpcode::kVertexFetch:
+      assert_always();
+      break;
   }
 
   EmitStoreVectorResult(instr.result);
@@ -727,6 +733,10 @@ void GlslShaderTranslator::EmitLoadOperand(size_t i,
       break;
     case InstructionStorageSource::kConstantBool:
       EmitSource("state.bool_consts");
+      break;
+    case InstructionStorageSource::kTextureFetchConstant:
+    case InstructionStorageSource::kVertexFetchConstant:
+      assert_always();
       break;
   }
   switch (op.storage_addressing_mode) {
@@ -814,6 +824,8 @@ void GlslShaderTranslator::EmitStoreResult(const InstructionResult& result,
       break;
     case InstructionStorageTarget::kDepth:
       EmitSourceDepth("gl_FragDepth");
+      break;
+    case InstructionStorageTarget::kNone:
       break;
   }
   if (uses_storage_index) {

--- a/src/xenia/gpu/shader.cc
+++ b/src/xenia/gpu/shader.cc
@@ -9,6 +9,7 @@
 
 #include "xenia/gpu/shader.h"
 
+#include <cinttypes>
 #include <cstring>
 
 #include "xenia/base/filesystem.h"
@@ -47,8 +48,8 @@ void Shader::Dump(const std::string& base_path, const char* path_prefix) {
 
   char txt_file_name[kMaxPath];
   std::snprintf(txt_file_name, xe::countof(txt_file_name),
-                "%s/shader_%s_%.16llX.%s", base_path.c_str(), path_prefix,
-                ucode_data_hash_,
+                "%s/shader_%s_%.16" PRIX64 ".%s", base_path.c_str(),
+                path_prefix, ucode_data_hash_,
                 shader_type_ == ShaderType::kVertex ? "vert" : "frag");
   FILE* f = fopen(txt_file_name, "w");
   if (f) {
@@ -70,8 +71,8 @@ void Shader::Dump(const std::string& base_path, const char* path_prefix) {
 
   char bin_file_name[kMaxPath];
   std::snprintf(bin_file_name, xe::countof(bin_file_name),
-                "%s/shader_%s_%.16llX.bin.%s", base_path.c_str(), path_prefix,
-                ucode_data_hash_,
+                "%s/shader_%s_%.16" PRIX64 ".bin.%s", base_path.c_str(),
+                path_prefix, ucode_data_hash_,
                 shader_type_ == ShaderType::kVertex ? "vert" : "frag");
   f = fopen(bin_file_name, "w");
   if (f) {

--- a/src/xenia/gpu/shader_translator.cc
+++ b/src/xenia/gpu/shader_translator.cc
@@ -184,12 +184,12 @@ void ShaderTranslator::GatherBindingInformation(
           auto& op = *reinterpret_cast<const AluInstruction*>(ucode_dwords_ +
                                                               instr_offset * 3);
           if (op.has_vector_op() && op.is_export()) {
-            if (op.vector_dest() >= 0 && op.vector_dest() <= 3) {
+            if (op.vector_dest() <= 3) {
               writes_color_targets_[op.vector_dest()] = true;
             }
           }
           if (op.has_scalar_op() && op.is_export()) {
-            if (op.vector_dest() >= 0 && op.vector_dest() <= 3) {
+            if (op.vector_dest() <= 3) {
               writes_color_targets_[op.vector_dest()] = true;
             }
           }

--- a/src/xenia/gpu/shader_translator.cc
+++ b/src/xenia/gpu/shader_translator.cc
@@ -159,7 +159,7 @@ void ShaderTranslator::GatherBindingInformation(
     case ControlFlowOpcode::kCondExecPred:
     case ControlFlowOpcode::kCondExecPredEnd:
     case ControlFlowOpcode::kCondExecPredClean:
-    case ControlFlowOpcode::kCondExecPredCleanEnd:
+    case ControlFlowOpcode::kCondExecPredCleanEnd: {
       uint32_t sequence = cf.exec.sequence();
       for (uint32_t instr_offset = cf.exec.address();
            instr_offset < cf.exec.address() + cf.exec.count();
@@ -195,6 +195,8 @@ void ShaderTranslator::GatherBindingInformation(
           }
         }
       }
+    } break;
+    default:
       break;
   }
 }
@@ -248,6 +250,9 @@ void ShaderTranslator::GatherTextureBindingInformation(
     case FetchOpcode::kSetTextureGradientsVert:
       // Doesn't use bindings.
       return;
+    default:
+      // Continue.
+      break;
   }
   Shader::TextureBinding binding;
   binding.binding_index = texture_bindings_.size();
@@ -270,6 +275,9 @@ void AddControlFlowTargetLabel(const ControlFlowInstruction& cf,
       break;
     case ControlFlowOpcode::kCondJmp:
       label_addresses->insert(cf.cond_jmp.address());
+      break;
+    default:
+      // Ignored.
       break;
   }
 }
@@ -435,6 +443,8 @@ void ShaderTranslator::TranslateControlFlowCondExec(
       i.opcode_name = "cexece";
       i.is_end = true;
       break;
+    default:
+      break;
   }
   i.instruction_address = cf.address();
   i.instruction_count = cf.count();
@@ -445,6 +455,8 @@ void ShaderTranslator::TranslateControlFlowCondExec(
     case ControlFlowOpcode::kCondExec:
     case ControlFlowOpcode::kCondExecEnd:
       i.clean = false;
+      break;
+    default:
       break;
   }
   i.is_yield = cf.is_yield();

--- a/src/xenia/gpu/shader_translator_disasm.cc
+++ b/src/xenia/gpu/shader_translator_disasm.cc
@@ -45,6 +45,8 @@ void DisassembleResultOperand(const InstructionResult& result,
     case InstructionStorageTarget::kDepth:
       out->Append("oDepth");
       break;
+    case InstructionStorageTarget::kNone:
+      break;
   }
   if (uses_storage_index) {
     switch (result.storage_addressing_mode) {
@@ -89,6 +91,10 @@ void DisassembleSourceOperand(const InstructionOperand& op, StringBuffer* out) {
       break;
     case InstructionStorageSource::kConstantBool:
       out->Append('b');
+      break;
+    case InstructionStorageSource::kTextureFetchConstant:
+    case InstructionStorageSource::kVertexFetchConstant:
+      assert_always();
       break;
   }
   if (op.is_absolute_value) {

--- a/src/xenia/ui/imgui_drawer.cc
+++ b/src/xenia/ui/imgui_drawer.cc
@@ -274,6 +274,9 @@ void ImGuiDrawer::OnMouseDown(MouseEvent* e) {
     case xe::ui::MouseEvent::Button::kRight: {
       io.MouseDown[1] = true;
     } break;
+    default: {
+      // Ignored.
+    } break;
   }
 }
 
@@ -291,6 +294,9 @@ void ImGuiDrawer::OnMouseUp(MouseEvent* e) {
     } break;
     case xe::ui::MouseEvent::Button::kRight: {
       io.MouseDown[1] = false;
+    } break;
+    default: {
+      // Ignored.
     } break;
   }
 }

--- a/src/xenia/ui/window.cc
+++ b/src/xenia/ui/window.cc
@@ -9,6 +9,8 @@
 
 #include "xenia/ui/window.h"
 
+#include <algorithm>
+
 #include "third_party/imgui/imgui.h"
 #include "xenia/base/assert.h"
 #include "xenia/base/clock.h"


### PR DESCRIPTION
Ran the ol' clang again. These fixes are pretty simple so they should not cause any problem. Almost half of it is to handle all enum values in switch-cases. Compiled on Windows and Linux, quick test on Windows.

There is more to come, I'm stubbing the code along so clang can eventually compile all of Xenia.