### PR TITLE
Rebrand the Xenia window with module metadata

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -190,6 +190,7 @@ solution("xenia")
   include("src/xenia/ui/gl")
   include("src/xenia/ui/spirv")
   include("src/xenia/vfs")
+  include("src/xenia/xdbf")
 
   if os.is("windows") then
     include("src/xenia/apu/xaudio2")

--- a/src/xenia/app/emulator_window.cc
+++ b/src/xenia/app/emulator_window.cc
@@ -288,11 +288,16 @@ void EmulatorWindow::ShowHelpWebsite() { LaunchBrowser("http://xenia.jp"); }
 
 void EmulatorWindow::UpdateTitle() {
   std::wstring title(base_title_);
-  if (Clock::guest_time_scalar() != 1.0) {
-    title += L" (@";
-    title += xe::to_wstring(std::to_string(Clock::guest_time_scalar()));
-    title += L"x)";
+
+  const std::wstring &game_title(emulator()->game_title());
+  if (!game_title.empty()) {
+    title = game_title + L" - " + title;
   }
+
+  if (Clock::guest_time_scalar() != 1.0) {
+    title += xe::format_string(L" (@%.2fx)", Clock::guest_time_scalar());
+  }
+
   window_->set_title(title);
 }
 

--- a/src/xenia/app/emulator_window.h
+++ b/src/xenia/app/emulator_window.h
@@ -35,11 +35,12 @@ class EmulatorWindow {
   ui::Loop* loop() const { return loop_.get(); }
   ui::Window* window() const { return window_.get(); }
 
+  void UpdateTitle();
+
  private:
   explicit EmulatorWindow(Emulator* emulator);
 
   bool Initialize();
-  void UpdateTitle();
 
   void CpuTimeScalarReset();
   void CpuTimeScalarSetHalf();

--- a/src/xenia/app/premake5.lua
+++ b/src/xenia/app/premake5.lua
@@ -25,6 +25,7 @@ project("xenia-app")
     "xenia-ui",
     "xenia-ui-gl",
     "xenia-vfs",
+    "xenia-xdbf",
   })
   flags({
     "WinMain",  -- Use WinMain instead of main.

--- a/src/xenia/app/xenia_main.cc
+++ b/src/xenia/app/xenia_main.cc
@@ -195,7 +195,8 @@ int xenia_main(const std::vector<std::wstring>& args) {
     // Normalize the path and make absolute.
     std::wstring abs_path = xe::to_absolute_path(path);
 
-    result = emulator->LaunchPath(abs_path);
+    result = emulator->LaunchPath(abs_path,
+                                  [&]() { emulator_window->UpdateTitle(); });
     if (XFAILED(result)) {
       XELOGE("Failed to launch target: %.8X", result);
       emulator.reset();

--- a/src/xenia/cpu/xex_module.cc
+++ b/src/xenia/cpu/xex_module.cc
@@ -465,8 +465,8 @@ bool XexModule::SetupLibraryImports(const char* name,
         GuestFunction::ExternHandler handler = nullptr;
         if (kernel_export) {
           if (kernel_export->function_data.trampoline) {
-            handler = (GuestFunction::ExternHandler)kernel_export
-                          ->function_data.trampoline;
+            handler = (GuestFunction::ExternHandler)
+                          kernel_export->function_data.trampoline;
           } else {
             handler =
                 (GuestFunction::ExternHandler)kernel_export->function_data.shim;

--- a/src/xenia/emulator.cc
+++ b/src/xenia/emulator.cc
@@ -526,13 +526,19 @@ X_STATUS Emulator::CompleteLaunch(const std::wstring& path,
       if (xdb_ptr != nullptr) {
         xe::xdbf::XdbfWrapper db;
         if (db.initialize(xdb_ptr, static_cast<size_t>(resource_size))) {
-          std::wstring title(xe::to_wstring(xe::xdbf::get_title(db)));
-          display_window_->set_title(title);
 
+          std::string game_title(xe::xdbf::get_title(db));
+          if (!game_title.empty()) {
+            game_title_ = xe::to_wstring(game_title);
+            // TODO(x1nixmzeng): Need to somehow callback to
+            // EmulatorWindow::UpdateTitle
+            display_window_->set_title(game_title_ + L" - " +
+                                       display_window_->title());
+          }
           xe::xdbf::XdbfBlock icon_block = xe::xdbf::get_icon(db);
           if (icon_block.buffer != nullptr) {
-            display_window_->set_icon_from_buffer(icon_block.buffer,
-                                                  icon_block.size);
+            display_window_->SetIconFromBuffer(icon_block.buffer,
+                                               icon_block.size);
           }
         }
       }

--- a/src/xenia/emulator.cc
+++ b/src/xenia/emulator.cc
@@ -514,28 +514,29 @@ X_STATUS Emulator::CompleteLaunch(const std::wstring& path,
     if (!main_xthread) {
       return X_STATUS_UNSUCCESSFUL;
     }
-	
-	// Try and load the resource database (xex only)
-	char title[9] = { 0 };
-	sprintf(title, "%08X", module->title_id());
-	
-	uint32_t resource_data = 0;
-	uint32_t resource_size = 0;
-	if (XSUCCEEDED(module->GetSection(title, &resource_data, &resource_size))) {
-		auto xdb_ptr = module->memory()->TranslateVirtual(resource_data);
-		if (xdb_ptr != nullptr) {
-			xe::xdbf::XdbfWrapper db;
-			if (db.initialize(xdb_ptr, static_cast<size_t>(resource_size))) {
-				std::wstring title(xe::to_wstring(xe::xdbf::get_title(db)));
-				display_window_->set_title(title);
 
-				xe::xdbf::XdbfBlock icon_block = xe::xdbf::get_icon(db);
-				if (icon_block.buffer != nullptr) {
-					display_window_->set_icon_from_buffer(icon_block.buffer, icon_block.size);
-				}
-			}
-		}
-	}
+    // Try and load the resource database (xex only)
+    char title[9] = {0};
+    sprintf(title, "%08X", module->title_id());
+
+    uint32_t resource_data = 0;
+    uint32_t resource_size = 0;
+    if (XSUCCEEDED(module->GetSection(title, &resource_data, &resource_size))) {
+      auto xdb_ptr = module->memory()->TranslateVirtual(resource_data);
+      if (xdb_ptr != nullptr) {
+        xe::xdbf::XdbfWrapper db;
+        if (db.initialize(xdb_ptr, static_cast<size_t>(resource_size))) {
+          std::wstring title(xe::to_wstring(xe::xdbf::get_title(db)));
+          display_window_->set_title(title);
+
+          xe::xdbf::XdbfBlock icon_block = xe::xdbf::get_icon(db);
+          if (icon_block.buffer != nullptr) {
+            display_window_->set_icon_from_buffer(icon_block.buffer,
+                                                  icon_block.size);
+          }
+        }
+      }
+    }
 
     main_thread_ = main_xthread->thread();
     WaitUntilExit();

--- a/src/xenia/emulator.cc
+++ b/src/xenia/emulator.cc
@@ -526,9 +526,13 @@ X_STATUS Emulator::CompleteLaunch(const std::wstring& path,
 		if (xdb_ptr != nullptr) {
 			xe::xdbf::XdbfWrapper db;
 			if (db.initialize(xdb_ptr, static_cast<size_t>(resource_size))) {
-				// TODO(x1nixmzeng): Set the application icon
 				std::wstring title(xe::to_wstring(xe::xdbf::get_title(db)));
 				display_window_->set_title(title);
+
+				xe::xdbf::XdbfBlock icon_block = xe::xdbf::get_icon(db);
+				if (icon_block.buffer != nullptr) {
+					display_window_->set_icon_from_buffer(icon_block.buffer, icon_block.size);
+				}
 			}
 		}
 	}

--- a/src/xenia/emulator.h
+++ b/src/xenia/emulator.h
@@ -54,7 +54,7 @@ class Emulator {
   const std::wstring& command_line() const { return command_line_; }
 
   // Title of the game in the default language.
-  const std::wstring &game_title() const { return game_title_; }
+  const std::wstring& game_title() const { return game_title_; }
 
   // Window used for displaying graphical output.
   ui::Window* display_window() const { return display_window_; }
@@ -109,17 +109,18 @@ class Emulator {
   // Launches a game from the given file path.
   // This will attempt to infer the type of the given file (such as an iso, etc)
   // using heuristics.
-  X_STATUS LaunchPath(std::wstring path);
+  X_STATUS LaunchPath(std::wstring path, std::function<void()> on_launch);
 
   // Launches a game from a .xex file by mounting the containing folder as if it
   // was an extracted STFS container.
-  X_STATUS LaunchXexFile(std::wstring path);
+  X_STATUS LaunchXexFile(std::wstring path, std::function<void()> on_launch);
 
   // Launches a game from a disc image file (.iso, etc).
-  X_STATUS LaunchDiscImage(std::wstring path);
+  X_STATUS LaunchDiscImage(std::wstring path, std::function<void()> on_launch);
 
   // Launches a game from an STFS container file.
-  X_STATUS LaunchStfsContainer(std::wstring path);
+  X_STATUS LaunchStfsContainer(std::wstring path,
+                               std::function<void()> on_launch);
 
   void Pause();
   void Resume();
@@ -134,8 +135,9 @@ class Emulator {
   static bool ExceptionCallbackThunk(Exception* ex, void* data);
   bool ExceptionCallback(Exception* ex);
 
-  X_STATUS CompleteLaunch(const std::wstring& path,
-                          const std::string& module_path);
+  X_STATUS CompleteLaunch(const std::wstring &path,
+                          const std::string &module_path,
+                          std::function<void()> on_launch);
 
   std::wstring command_line_;
   std::wstring game_title_;

--- a/src/xenia/emulator.h
+++ b/src/xenia/emulator.h
@@ -53,6 +53,9 @@ class Emulator {
   // Full command line used when launching the process.
   const std::wstring& command_line() const { return command_line_; }
 
+  // Title of the game in the default language.
+  const std::wstring &game_title() const { return game_title_; }
+
   // Window used for displaying graphical output.
   ui::Window* display_window() const { return display_window_; }
 
@@ -135,6 +138,7 @@ class Emulator {
                           const std::string& module_path);
 
   std::wstring command_line_;
+  std::wstring game_title_;
 
   ui::Window* display_window_;
 

--- a/src/xenia/kernel/kernel_module.cc
+++ b/src/xenia/kernel/kernel_module.cc
@@ -105,8 +105,8 @@ uint32_t KernelModule::GetProcAddressByOrdinal(uint16_t ordinal) {
 
       cpu::GuestFunction::ExternHandler handler = nullptr;
       if (export_entry->function_data.trampoline) {
-        handler = (cpu::GuestFunction::ExternHandler)export_entry
-                      ->function_data.trampoline;
+        handler = (cpu::GuestFunction::ExternHandler)
+                      export_entry->function_data.trampoline;
       } else {
         handler =
             (cpu::GuestFunction::ExternHandler)export_entry->function_data.shim;

--- a/src/xenia/kernel/user_module.cc
+++ b/src/xenia/kernel/user_module.cc
@@ -208,7 +208,7 @@ X_STATUS UserModule::GetSection(const char* name, uint32_t* out_section_data,
     return X_STATUS_NOT_FOUND;
   }
 
-  uint32_t count = (resource_header->size - 4) / 16;
+  uint32_t count = (resource_header->size - 4) / sizeof(xex2_resource);
   for (uint32_t i = 0; i < count; i++) {
     auto& res = resource_header->resources[i];
     if (std::strncmp(name, res.name, 8) == 0) {

--- a/src/xenia/ui/window.h
+++ b/src/xenia/ui/window.h
@@ -53,7 +53,7 @@ class Window {
     return true;
   }
 
-  virtual bool SetIconFromBuffer(void *buffer, size_t size) = 0;
+  virtual bool SetIconFromBuffer(void* buffer, size_t size) = 0;
 
   virtual bool is_fullscreen() const { return false; }
   virtual void ToggleFullscreen(bool fullscreen) {}

--- a/src/xenia/ui/window.h
+++ b/src/xenia/ui/window.h
@@ -53,7 +53,7 @@ class Window {
     return true;
   }
 
-  virtual bool set_icon_from_buffer(void *buffer, size_t size) = 0;
+  virtual bool SetIconFromBuffer(void *buffer, size_t size) = 0;
 
   virtual bool is_fullscreen() const { return false; }
   virtual void ToggleFullscreen(bool fullscreen) {}

--- a/src/xenia/ui/window.h
+++ b/src/xenia/ui/window.h
@@ -53,6 +53,8 @@ class Window {
     return true;
   }
 
+  virtual bool set_icon_from_buffer(void *buffer, size_t size) = 0;
+
   virtual bool is_fullscreen() const { return false; }
   virtual void ToggleFullscreen(bool fullscreen) {}
 

--- a/src/xenia/ui/window_win.cc
+++ b/src/xenia/ui/window_win.cc
@@ -167,7 +167,7 @@ bool Win32Window::set_title(const std::wstring& title) {
   return true;
 }
 
-bool Win32Window::SetIconFromBuffer(void *buffer, size_t size) {
+bool Win32Window::SetIconFromBuffer(void* buffer, size_t size) {
   if (icon_ != nullptr) {
     DestroyIcon(icon_);
   }

--- a/src/xenia/ui/window_win.cc
+++ b/src/xenia/ui/window_win.cc
@@ -32,8 +32,8 @@ Win32Window::~Win32Window() {
     hwnd_ = nullptr;
   }
   if (icon_ != nullptr) {
-	  DestroyIcon(icon_);
-	  icon_ = nullptr;
+    DestroyIcon(icon_);
+    icon_ = nullptr;
   }
 }
 
@@ -167,7 +167,7 @@ bool Win32Window::set_title(const std::wstring& title) {
   return true;
 }
 
-bool Win32Window::set_icon_from_buffer(void* buffer, size_t size) {
+bool Win32Window::SetIconFromBuffer(void *buffer, size_t size) {
   if (icon_ != nullptr) {
     DestroyIcon(icon_);
   }

--- a/src/xenia/ui/window_win.cc
+++ b/src/xenia/ui/window_win.cc
@@ -167,22 +167,23 @@ bool Win32Window::set_title(const std::wstring& title) {
   return true;
 }
 
-bool Win32Window::set_icon_from_buffer(void *buffer, size_t size) {
+bool Win32Window::set_icon_from_buffer(void* buffer, size_t size) {
+  if (icon_ != nullptr) {
+    DestroyIcon(icon_);
+  }
 
-	if (icon_ != nullptr) {
-		DestroyIcon(icon_);
-	}
-	
-	HICON icon = CreateIconFromResourceEx(reinterpret_cast<BYTE *>(buffer), static_cast<DWORD>(size), TRUE, 0x00030000, 0, 0, LR_DEFAULTCOLOR);
+  HICON icon = CreateIconFromResourceEx(reinterpret_cast<BYTE*>(buffer),
+                                        static_cast<DWORD>(size), TRUE,
+                                        0x00030000, 0, 0, LR_DEFAULTCOLOR);
 
-	if (icon != nullptr) {
-		icon_ = icon;
+  if (icon != nullptr) {
+    icon_ = icon;
 
-		SendMessage(hwnd_, WM_SETICON, ICON_BIG, reinterpret_cast<LPARAM>(icon));
-		SendMessage(hwnd_, WM_SETICON, ICON_SMALL, reinterpret_cast<LPARAM>(icon));
-	}
-	
-	return false;
+    SendMessage(hwnd_, WM_SETICON, ICON_BIG, reinterpret_cast<LPARAM>(icon));
+    SendMessage(hwnd_, WM_SETICON, ICON_SMALL, reinterpret_cast<LPARAM>(icon));
+  }
+
+  return false;
 }
 
 bool Win32Window::is_fullscreen() const { return fullscreen_; }

--- a/src/xenia/ui/window_win.cc
+++ b/src/xenia/ui/window_win.cc
@@ -14,11 +14,6 @@
 #include "xenia/base/platform_win.h"
 #include "xenia/ui/window_win.h"
 
-#include "third_party/stb/stb_image.h"
-
-#define STB_IMAGE_IMPLEMENTATION
-#include "third_party/stb/stb_image.h"
-
 namespace xe {
 namespace ui {
 
@@ -35,6 +30,10 @@ Win32Window::~Win32Window() {
     SetWindowLongPtr(hwnd_, GWLP_USERDATA, 0);
     CloseWindow(hwnd_);
     hwnd_ = nullptr;
+  }
+  if (icon_ != nullptr) {
+	  DestroyIcon(icon_);
+	  icon_ = nullptr;
   }
 }
 
@@ -174,35 +173,13 @@ bool Win32Window::set_icon_from_buffer(void *buffer, size_t size) {
 		DestroyIcon(icon_);
 	}
 	
-	// Convert the buffer for Windows
-	int width, height, bpp;
-	unsigned char *data = stbi_load_from_memory(reinterpret_cast<const stbi_uc*>(buffer), static_cast<int>(size), &width, &height, &bpp, 0);
-
-	int iSize = sizeof(BITMAPINFOHEADER);
-	int iSizeImage = width * height * bpp;
-
-	std::vector<uint8_t> bitmap(iSize + iSizeImage);
-	BITMAPINFOHEADER *pBitmap(reinterpret_cast<BITMAPINFOHEADER *>(bitmap.data()));
-
-	pBitmap->biSize = sizeof(BITMAPINFOHEADER);
-	pBitmap->biWidth = width;
-	pBitmap->biHeight = height;
-	pBitmap->biPlanes = 1;
-	pBitmap->biBitCount = bpp * 8;
-	pBitmap->biCompression = BI_RGB;
-	pBitmap->biSizeImage = iSizeImage;
-
-	unsigned char *pImage = bitmap.data() + iSize;
-
-	std::copy(data, data + iSizeImage, pImage);
-
-	HICON icon = CreateIconFromResourceEx((BYTE *)pBitmap, iSize + iSizeImage, TRUE, 0x00030000, width, height, LR_DEFAULTCOLOR);
+	HICON icon = CreateIconFromResourceEx(reinterpret_cast<BYTE *>(buffer), static_cast<DWORD>(size), TRUE, 0x00030000, 0, 0, LR_DEFAULTCOLOR);
 
 	if (icon != nullptr) {
+		icon_ = icon;
+
 		SendMessage(hwnd_, WM_SETICON, ICON_BIG, reinterpret_cast<LPARAM>(icon));
 		SendMessage(hwnd_, WM_SETICON, ICON_SMALL, reinterpret_cast<LPARAM>(icon));
-
-		icon_ = icon;
 	}
 	
 	return false;
@@ -339,9 +316,6 @@ void Win32Window::Close() {
   Close();
   OnClose();
   DestroyWindow(hwnd_);
-  if (icon_ != nullptr) {
-	  DestroyIcon(icon_);
-  }
 }
 
 void Win32Window::OnMainMenuChange() {

--- a/src/xenia/ui/window_win.h
+++ b/src/xenia/ui/window_win.h
@@ -31,7 +31,7 @@ class Win32Window : public Window {
   HWND hwnd() const { return hwnd_; }
 
   bool set_title(const std::wstring& title) override;
-  bool set_icon_from_buffer(void *buffer, size_t size) override;
+  bool SetIconFromBuffer(void *buffer, size_t size) override;
 
   bool is_fullscreen() const override;
   void ToggleFullscreen(bool fullscreen) override;

--- a/src/xenia/ui/window_win.h
+++ b/src/xenia/ui/window_win.h
@@ -31,7 +31,7 @@ class Win32Window : public Window {
   HWND hwnd() const { return hwnd_; }
 
   bool set_title(const std::wstring& title) override;
-  bool SetIconFromBuffer(void *buffer, size_t size) override;
+  bool SetIconFromBuffer(void* buffer, size_t size) override;
 
   bool is_fullscreen() const override;
   void ToggleFullscreen(bool fullscreen) override;

--- a/src/xenia/ui/window_win.h
+++ b/src/xenia/ui/window_win.h
@@ -31,6 +31,7 @@ class Win32Window : public Window {
   HWND hwnd() const { return hwnd_; }
 
   bool set_title(const std::wstring& title) override;
+  bool set_icon_from_buffer(void *buffer, size_t size) override;
 
   bool is_fullscreen() const override;
   void ToggleFullscreen(bool fullscreen) override;
@@ -68,6 +69,7 @@ class Win32Window : public Window {
   bool HandleKeyboard(UINT message, WPARAM wParam, LPARAM lParam);
 
   HWND hwnd_ = nullptr;
+  HICON icon_ = nullptr;
   bool closing_ = false;
   bool fullscreen_ = false;
 

--- a/src/xenia/xdbf/premake5.lua
+++ b/src/xenia/xdbf/premake5.lua
@@ -1,0 +1,17 @@
+project_root = "../../.."
+include(project_root.."/tools/build")
+
+group("src")
+project("xenia-xdbf")
+  uuid("a95b5fce-1083-4bff-a022-ffdd0bab3db0")
+  kind("StaticLib")
+  language("C++")
+  links({
+    "xenia-base",
+  })
+  defines({
+  })
+  includedirs({
+    project_root.."third_party/gflags/src",
+  })
+  recursive_platform_files()

--- a/src/xenia/xdbf/xdbf_utils.cc
+++ b/src/xenia/xdbf/xdbf_utils.cc
@@ -1,0 +1,141 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2016 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#include "xenia/xdbf/xdbf_utils.h"
+
+namespace xe {
+namespace xdbf {
+
+	XdbfWrapper::XdbfWrapper() = default;
+
+	XBDF_HEADER& XdbfWrapper::get_header() const
+	{
+		return *state_.header;
+	}
+	
+	XBDF_ENTRY& XdbfWrapper::get_entry(uint32_t n) const
+	{
+		return state_.entries[n];
+	}
+
+	XBDF_FILE_LOC& XdbfWrapper::get_file(uint32_t n) const
+	{
+		return state_.files[n];
+	}
+
+	bool XdbfWrapper::initialize(uint8_t* buffer, size_t length)
+	{
+		if (length <= sizeof(XBDF_HEADER)) {
+			return false;
+		}
+
+		XdbfState state;
+
+		state.data = buffer;
+		state.size = length;
+
+		uint8_t* ptr = state.data;
+
+		state.header = reinterpret_cast<XBDF_HEADER*>(ptr);
+		ptr += sizeof(XBDF_HEADER);
+
+		state.entries = reinterpret_cast<XBDF_ENTRY*>(ptr);
+		ptr += (sizeof(XBDF_ENTRY) * state.header->entry_max);
+
+		state.files = reinterpret_cast<XBDF_FILE_LOC*>(ptr);
+		ptr += (sizeof(XBDF_FILE_LOC) * state.header->free_max);
+
+		state.offset = ptr;
+
+		if (state.header->magic == 'XDBF') {
+			state_ = state;
+			return true;
+		}
+
+		return false;
+	}
+
+	XdbfBlock XdbfWrapper::get_entry(XdbfSection section, uint64_t id) const {
+		
+		XdbfBlock block = { nullptr,0 };
+		uint32_t x = 0;
+
+		while( x < get_header().entry_current ) {
+			auto &entry = get_entry(x);
+
+			if (entry.section == section && entry.id == id) {
+				block.buffer = state_.offset + entry.offset;
+				block.size = entry.size;
+				break;
+			}
+
+			++x;
+		}
+
+		return block;
+	}
+
+	std::vector<uint8_t> get_icon(XdbfWrapper& ref)
+	{
+		std::vector<uint8_t> icon;
+
+		XdbfBlock block = ref.get_entry(kSectionImage, 0x8000);
+
+		if (block.buffer != nullptr) {
+			icon.resize(block.size);
+			std::copy(block.buffer, block.buffer + block.size, icon.data());
+		}
+
+		return icon;
+	}
+
+	std::string get_title(XdbfWrapper& ref)
+	{
+		std::string title_str;
+
+		XdbfBlock block = ref.get_entry(kSectionMetadata, 0x58535443);
+		if (block.buffer != nullptr) {
+			XDBF_XSTC* xstc = reinterpret_cast<XDBF_XSTC*>(block.buffer);
+
+			assert_true(xstc->magic == 'XSTC');
+			uint32_t def_language = xstc->default_language;
+
+			XdbfBlock lang_block = ref.get_entry(kSectionStringTable, static_cast<uint64_t>(def_language));
+
+			if (lang_block.buffer != nullptr) {
+				XDBF_XSTR_HEADER* xstr_head = reinterpret_cast<XDBF_XSTR_HEADER*>(lang_block.buffer);
+
+				assert_true(xstr_head->magic == 'XSTR');
+				assert_true(xstr_head->version == 1);
+
+				uint16_t str_count = xstr_head->string_count;
+				uint8_t *currentAddress = lang_block.buffer + sizeof(XDBF_XSTR_HEADER);
+
+				uint16_t s = 0;
+				while( s < str_count && title_str.empty() ) {
+					XDBF_STRINGTABLE_ENTRY* entry = reinterpret_cast<XDBF_STRINGTABLE_ENTRY*>(currentAddress);
+					currentAddress += sizeof(XDBF_STRINGTABLE_ENTRY);
+					uint16_t len = entry->string_length;
+
+					if (entry->id == 0x00008000) {
+						title_str.resize(static_cast<size_t>(len));
+						std::copy(currentAddress, currentAddress + len, title_str.begin());
+					}
+
+					currentAddress += len;
+				}
+			}
+		}
+
+		return title_str;
+	}
+
+
+}  // namespace xdbf
+}  // namespace xe

--- a/src/xenia/xdbf/xdbf_utils.cc
+++ b/src/xenia/xdbf/xdbf_utils.cc
@@ -84,14 +84,14 @@ XdbfBlock XdbfWrapper::get_entry(XdbfSection section, uint64_t id) const {
   return block;
 }
 
-XdbfBlock get_icon(const XdbfWrapper &ref) {
+XdbfBlock get_icon(const XdbfWrapper& ref) {
   return ref.get_entry(kSectionImage, kIdTitle);
 }
 
-XdbfLocale get_default_language(const XdbfWrapper &ref) {
+XdbfLocale get_default_language(const XdbfWrapper& ref) {
   XdbfBlock block = ref.get_entry(kSectionMetadata, kIdXSTC);
   if (block.buffer != nullptr) {
-    XDBF_XSTC *xstc = reinterpret_cast<XDBF_XSTC *>(block.buffer);
+    XDBF_XSTC* xstc = reinterpret_cast<XDBF_XSTC*>(block.buffer);
     assert_true(xstc->magic == kMagicXSTC);
 
     uint32_t default_language = xstc->default_language;
@@ -101,7 +101,7 @@ XdbfLocale get_default_language(const XdbfWrapper &ref) {
   return kLocaleEnglish;
 }
 
-std::string get_title(const XdbfWrapper &ref) {
+std::string get_title(const XdbfWrapper& ref) {
   std::string title_str;
 
   uint64_t language_id = static_cast<uint64_t>(get_default_language(ref));
@@ -109,19 +109,19 @@ std::string get_title(const XdbfWrapper &ref) {
   XdbfBlock lang_block = ref.get_entry(kSectionStringTable, language_id);
 
   if (lang_block.buffer != nullptr) {
-    XDBF_XSTR_HEADER *xstr_head =
-        reinterpret_cast<XDBF_XSTR_HEADER *>(lang_block.buffer);
+    XDBF_XSTR_HEADER* xstr_head =
+        reinterpret_cast<XDBF_XSTR_HEADER*>(lang_block.buffer);
 
     assert_true(xstr_head->magic == kMagicXSTR);
     assert_true(xstr_head->version == 1);
 
     uint16_t str_count = xstr_head->string_count;
-    uint8_t *currentAddress = lang_block.buffer + sizeof(XDBF_XSTR_HEADER);
+    uint8_t* currentAddress = lang_block.buffer + sizeof(XDBF_XSTR_HEADER);
 
     uint16_t s = 0;
     while (s < str_count && title_str.empty()) {
-      XDBF_STRINGTABLE_ENTRY *entry =
-          reinterpret_cast<XDBF_STRINGTABLE_ENTRY *>(currentAddress);
+      XDBF_STRINGTABLE_ENTRY* entry =
+          reinterpret_cast<XDBF_STRINGTABLE_ENTRY*>(currentAddress);
       currentAddress += sizeof(XDBF_STRINGTABLE_ENTRY);
       uint16_t len = entry->string_length;
 

--- a/src/xenia/xdbf/xdbf_utils.cc
+++ b/src/xenia/xdbf/xdbf_utils.cc
@@ -81,18 +81,9 @@ namespace xdbf {
 		return block;
 	}
 
-	std::vector<uint8_t> get_icon(XdbfWrapper& ref)
+	XdbfBlock get_icon(XdbfWrapper& ref)
 	{
-		std::vector<uint8_t> icon;
-
-		XdbfBlock block = ref.get_entry(kSectionImage, 0x8000);
-
-		if (block.buffer != nullptr) {
-			icon.resize(block.size);
-			std::copy(block.buffer, block.buffer + block.size, icon.data());
-		}
-
-		return icon;
+		return ref.get_entry(kSectionImage, 0x8000);
 	}
 
 	std::string get_title(XdbfWrapper& ref)

--- a/src/xenia/xdbf/xdbf_utils.h
+++ b/src/xenia/xdbf/xdbf_utils.h
@@ -119,9 +119,9 @@ class XdbfWrapper {
   XdbfState state_;
 };
 
-XdbfBlock get_icon(const XdbfWrapper &ref);
-XdbfLocale get_default_language(const XdbfWrapper &ref);
-std::string get_title(const XdbfWrapper &ref);
+XdbfBlock get_icon(const XdbfWrapper& ref);
+XdbfLocale get_default_language(const XdbfWrapper& ref);
+std::string get_title(const XdbfWrapper& ref);
 
 }  // namespace xdbf
 }  // namespace xe

--- a/src/xenia/xdbf/xdbf_utils.h
+++ b/src/xenia/xdbf/xdbf_utils.h
@@ -10,8 +10,8 @@
 #ifndef XENIA_XDBF_XDBF_UTILS_H_
 #define XENIA_XDBF_XDBF_UTILS_H_
 
-#include <vector>
 #include <string>
+#include <vector>
 
 #include "xenia/base/memory.h"
 
@@ -27,19 +27,26 @@ enum XdbfSection : uint16_t {
   kSectionStringTable = 0x0003,
 };
 
+// Found by dumping the kSectionStringTable sections of various games:
+
 enum XdbfLocale : uint32_t {
-  kLocaleDefault = 0,
   kLocaleEnglish = 1,
   kLocaleJapanese = 2,
+  kLocaleGerman = 3,
+  kLocaleFrench = 4,
+  kLocaleSpanish = 5,
+  kLocaleItalian = 6,
+  kLocaleKorean = 7,
+  kLocaleChinese = 8,
 };
 
 struct XBDF_HEADER {
   xe::be<uint32_t> magic;
   xe::be<uint32_t> version;
-  xe::be<uint32_t> entry_max;
-  xe::be<uint32_t> entry_current;
-  xe::be<uint32_t> free_max;
-  xe::be<uint32_t> free_current;
+  xe::be<uint32_t> entry_count;
+  xe::be<uint32_t> entry_used;
+  xe::be<uint32_t> free_count;
+  xe::be<uint32_t> free_used;
 };
 static_assert_size(XBDF_HEADER, 24);
 
@@ -112,8 +119,9 @@ class XdbfWrapper {
   XdbfState state_;
 };
 
-XdbfBlock get_icon(XdbfWrapper& ref);
-std::string get_title(XdbfWrapper& ref);
+XdbfBlock get_icon(const XdbfWrapper &ref);
+XdbfLocale get_default_language(const XdbfWrapper &ref);
+std::string get_title(const XdbfWrapper &ref);
 
 }  // namespace xdbf
 }  // namespace xe

--- a/src/xenia/xdbf/xdbf_utils.h
+++ b/src/xenia/xdbf/xdbf_utils.h
@@ -112,7 +112,7 @@ namespace xdbf {
 		XdbfState state_;
 	};
 
-	std::vector<uint8_t> get_icon(XdbfWrapper& ref);
+	XdbfBlock get_icon(XdbfWrapper& ref);
 	std::string get_title(XdbfWrapper& ref);
 
 

--- a/src/xenia/xdbf/xdbf_utils.h
+++ b/src/xenia/xdbf/xdbf_utils.h
@@ -1,0 +1,122 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2016 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_XDBF_XDBF_UTILS_H_
+#define XENIA_XDBF_XDBF_UTILS_H_
+
+#include <vector>
+#include <string>
+
+#include "xenia/base/memory.h"
+
+namespace xe {
+namespace xdbf {
+	
+	// http://freestyledash.googlecode.com/svn/trunk/Freestyle/Tools/XEX/SPA.h
+	// http://freestyledash.googlecode.com/svn/trunk/Freestyle/Tools/XEX/SPA.cpp
+
+	enum XdbfSection : uint16_t {
+		kSectionMetadata = 0x0001,
+		kSectionImage = 0x0002,
+		kSectionStringTable = 0x0003,
+	};
+
+	enum XdbfLocale : uint32_t {
+		kLocaleDefault = 0,
+		kLocaleEnglish = 1,
+		kLocaleJapanese = 2,
+	};
+
+	struct XBDF_HEADER {
+		xe::be<uint32_t> magic;
+		xe::be<uint32_t> version;
+		xe::be<uint32_t> entry_max;
+		xe::be<uint32_t> entry_current;
+		xe::be<uint32_t> free_max;
+		xe::be<uint32_t> free_current;
+	};
+	static_assert_size(XBDF_HEADER, 24);
+
+#pragma pack(push, 1)
+	struct XBDF_ENTRY {
+		xe::be<uint16_t> section;
+		xe::be<uint64_t> id;
+		xe::be<uint32_t> offset;
+		xe::be<uint32_t> size;
+	};
+	static_assert_size(XBDF_ENTRY, 18);
+#pragma pack(pop)
+
+	struct XBDF_FILE_LOC {
+		xe::be<uint32_t> offset;
+		xe::be<uint32_t> size;
+	};
+	static_assert_size(XBDF_FILE_LOC, 8);
+
+	struct XDBF_XSTC {
+		xe::be<uint32_t> magic;
+		xe::be<uint32_t> version;
+		xe::be<uint32_t> size;
+		xe::be<uint32_t> default_language;
+	};
+	static_assert_size(XDBF_XSTC, 16);
+
+#pragma pack(push, 1)
+	struct XDBF_XSTR_HEADER {
+		xe::be<uint32_t> magic;
+		xe::be<uint32_t> version;
+		xe::be<uint32_t> size;
+		xe::be<uint16_t> string_count;
+	};
+	static_assert_size(XDBF_XSTR_HEADER, 14);
+#pragma pack(pop)
+
+	struct XDBF_STRINGTABLE_ENTRY {
+		xe::be<uint16_t> id;
+		xe::be<uint16_t> string_length;
+	};
+	static_assert_size(XDBF_STRINGTABLE_ENTRY, 4);
+
+	struct XdbfState {
+		XBDF_HEADER* header;
+		XBDF_ENTRY* entries;
+		XBDF_FILE_LOC* files;
+		uint8_t* offset;
+		uint8_t* data;
+		size_t size;
+	};
+
+	struct XdbfBlock {
+		uint8_t* buffer;
+		size_t size;
+	};
+
+	class XdbfWrapper {
+	public:
+		XdbfWrapper();
+
+		bool initialize(uint8_t* buffer, size_t length);
+		XdbfBlock get_entry(XdbfSection section, uint64_t id) const;
+
+	private:
+		XBDF_HEADER& get_header() const;
+		XBDF_ENTRY& get_entry(uint32_t n) const;
+		XBDF_FILE_LOC& get_file(uint32_t n) const;
+
+		XdbfState state_;
+	};
+
+	std::vector<uint8_t> get_icon(XdbfWrapper& ref);
+	std::string get_title(XdbfWrapper& ref);
+
+
+}  // namespace xdbf
+}  // namespace xe
+
+#endif  // XENIA_XDBF_XDBF_UTILS_H_

--- a/src/xenia/xdbf/xdbf_utils.h
+++ b/src/xenia/xdbf/xdbf_utils.h
@@ -17,104 +17,103 @@
 
 namespace xe {
 namespace xdbf {
-	
-	// http://freestyledash.googlecode.com/svn/trunk/Freestyle/Tools/XEX/SPA.h
-	// http://freestyledash.googlecode.com/svn/trunk/Freestyle/Tools/XEX/SPA.cpp
 
-	enum XdbfSection : uint16_t {
-		kSectionMetadata = 0x0001,
-		kSectionImage = 0x0002,
-		kSectionStringTable = 0x0003,
-	};
+// http://freestyledash.googlecode.com/svn/trunk/Freestyle/Tools/XEX/SPA.h
+// http://freestyledash.googlecode.com/svn/trunk/Freestyle/Tools/XEX/SPA.cpp
 
-	enum XdbfLocale : uint32_t {
-		kLocaleDefault = 0,
-		kLocaleEnglish = 1,
-		kLocaleJapanese = 2,
-	};
+enum XdbfSection : uint16_t {
+  kSectionMetadata = 0x0001,
+  kSectionImage = 0x0002,
+  kSectionStringTable = 0x0003,
+};
 
-	struct XBDF_HEADER {
-		xe::be<uint32_t> magic;
-		xe::be<uint32_t> version;
-		xe::be<uint32_t> entry_max;
-		xe::be<uint32_t> entry_current;
-		xe::be<uint32_t> free_max;
-		xe::be<uint32_t> free_current;
-	};
-	static_assert_size(XBDF_HEADER, 24);
+enum XdbfLocale : uint32_t {
+  kLocaleDefault = 0,
+  kLocaleEnglish = 1,
+  kLocaleJapanese = 2,
+};
 
-#pragma pack(push, 1)
-	struct XBDF_ENTRY {
-		xe::be<uint16_t> section;
-		xe::be<uint64_t> id;
-		xe::be<uint32_t> offset;
-		xe::be<uint32_t> size;
-	};
-	static_assert_size(XBDF_ENTRY, 18);
-#pragma pack(pop)
-
-	struct XBDF_FILE_LOC {
-		xe::be<uint32_t> offset;
-		xe::be<uint32_t> size;
-	};
-	static_assert_size(XBDF_FILE_LOC, 8);
-
-	struct XDBF_XSTC {
-		xe::be<uint32_t> magic;
-		xe::be<uint32_t> version;
-		xe::be<uint32_t> size;
-		xe::be<uint32_t> default_language;
-	};
-	static_assert_size(XDBF_XSTC, 16);
+struct XBDF_HEADER {
+  xe::be<uint32_t> magic;
+  xe::be<uint32_t> version;
+  xe::be<uint32_t> entry_max;
+  xe::be<uint32_t> entry_current;
+  xe::be<uint32_t> free_max;
+  xe::be<uint32_t> free_current;
+};
+static_assert_size(XBDF_HEADER, 24);
 
 #pragma pack(push, 1)
-	struct XDBF_XSTR_HEADER {
-		xe::be<uint32_t> magic;
-		xe::be<uint32_t> version;
-		xe::be<uint32_t> size;
-		xe::be<uint16_t> string_count;
-	};
-	static_assert_size(XDBF_XSTR_HEADER, 14);
+struct XBDF_ENTRY {
+  xe::be<uint16_t> section;
+  xe::be<uint64_t> id;
+  xe::be<uint32_t> offset;
+  xe::be<uint32_t> size;
+};
+static_assert_size(XBDF_ENTRY, 18);
 #pragma pack(pop)
 
-	struct XDBF_STRINGTABLE_ENTRY {
-		xe::be<uint16_t> id;
-		xe::be<uint16_t> string_length;
-	};
-	static_assert_size(XDBF_STRINGTABLE_ENTRY, 4);
+struct XBDF_FILE_LOC {
+  xe::be<uint32_t> offset;
+  xe::be<uint32_t> size;
+};
+static_assert_size(XBDF_FILE_LOC, 8);
 
-	struct XdbfState {
-		XBDF_HEADER* header;
-		XBDF_ENTRY* entries;
-		XBDF_FILE_LOC* files;
-		uint8_t* offset;
-		uint8_t* data;
-		size_t size;
-	};
+struct XDBF_XSTC {
+  xe::be<uint32_t> magic;
+  xe::be<uint32_t> version;
+  xe::be<uint32_t> size;
+  xe::be<uint32_t> default_language;
+};
+static_assert_size(XDBF_XSTC, 16);
 
-	struct XdbfBlock {
-		uint8_t* buffer;
-		size_t size;
-	};
+#pragma pack(push, 1)
+struct XDBF_XSTR_HEADER {
+  xe::be<uint32_t> magic;
+  xe::be<uint32_t> version;
+  xe::be<uint32_t> size;
+  xe::be<uint16_t> string_count;
+};
+static_assert_size(XDBF_XSTR_HEADER, 14);
+#pragma pack(pop)
 
-	class XdbfWrapper {
-	public:
-		XdbfWrapper();
+struct XDBF_STRINGTABLE_ENTRY {
+  xe::be<uint16_t> id;
+  xe::be<uint16_t> string_length;
+};
+static_assert_size(XDBF_STRINGTABLE_ENTRY, 4);
 
-		bool initialize(uint8_t* buffer, size_t length);
-		XdbfBlock get_entry(XdbfSection section, uint64_t id) const;
+struct XdbfState {
+  XBDF_HEADER* header;
+  XBDF_ENTRY* entries;
+  XBDF_FILE_LOC* files;
+  uint8_t* offset;
+  uint8_t* data;
+  size_t size;
+};
 
-	private:
-		XBDF_HEADER& get_header() const;
-		XBDF_ENTRY& get_entry(uint32_t n) const;
-		XBDF_FILE_LOC& get_file(uint32_t n) const;
+struct XdbfBlock {
+  uint8_t* buffer;
+  size_t size;
+};
 
-		XdbfState state_;
-	};
+class XdbfWrapper {
+ public:
+  XdbfWrapper();
 
-	XdbfBlock get_icon(XdbfWrapper& ref);
-	std::string get_title(XdbfWrapper& ref);
+  bool initialize(uint8_t* buffer, size_t length);
+  XdbfBlock get_entry(XdbfSection section, uint64_t id) const;
 
+ private:
+  XBDF_HEADER& get_header() const;
+  XBDF_ENTRY& get_entry(uint32_t n) const;
+  XBDF_FILE_LOC& get_file(uint32_t n) const;
+
+  XdbfState state_;
+};
+
+XdbfBlock get_icon(XdbfWrapper& ref);
+std::string get_title(XdbfWrapper& ref);
 
 }  // namespace xdbf
 }  // namespace xe


### PR DESCRIPTION
Replaces window title and icon with the resources in the current module - part of #506 

Example:

![limbo_example](https://cloud.githubusercontent.com/assets/327967/12182681/a1f22c3a-b581-11e5-9d62-300dad8faf39.png)
