### PR TITLE
Decouple MicroProfilerFlip from Profiler::Present

### DIFF
--- a/src/xenia/base/profiling.cc
+++ b/src/xenia/base/profiling.cc
@@ -236,7 +236,6 @@ void Profiler::set_window(ui::Window* window) {
 
 void Profiler::Present() {
   SCOPE_profile_cpu_f("internal");
-  MicroProfileFlip();
 #if XE_OPTION_PROFILING_UI
   if (!window_ || !drawer_) {
     return;
@@ -246,6 +245,8 @@ void Profiler::Present() {
   drawer_->End();
 #endif  // XE_OPTION_PROFILING_UI
 }
+
+void Profiler::Flip() { MicroProfileFlip(); }
 
 #else
 

--- a/src/xenia/base/profiling.h
+++ b/src/xenia/base/profiling.h
@@ -168,6 +168,8 @@ class Profiler {
   static ui::MicroprofileDrawer* drawer() { return drawer_.get(); }
   // Presents the profiler to the bound display, if any.
   static void Present();
+  // Starts a new frame on the profiler
+  static void Flip();
 
  private:
   static ui::Window* window_;

--- a/src/xenia/gpu/command_processor.cc
+++ b/src/xenia/gpu/command_processor.cc
@@ -693,6 +693,8 @@ bool CommandProcessor::ExecutePacketType3_XE_SWAP(RingBuffer* reader,
 
   XELOGI("XE_SWAP");
 
+  Profiler::Flip();
+
   // Xenia-specific VdSwap hook.
   // VdSwap will post this to tell us we need to swap the screen/fire an
   // interrupt.


### PR DESCRIPTION
* Makes moving the mouse around on-screen not start a new profiler frame