### PR TITLE
More shader changes

### DIFF
--- a/src/xenia/gpu/glsl_shader_translator.cc
+++ b/src/xenia/gpu/glsl_shader_translator.cc
@@ -179,7 +179,7 @@ vec4 cube(vec4 src0, vec4 src1) {
   float s = (sc / ma + 1.0) / 2.0;
   float t = (tc / ma + 1.0) / 2.0;
   return vec4(t, s, 2.0 * ma, float(face_id));
-};
+}
 )");
 
   if (is_vertex_shader()) {
@@ -234,7 +234,7 @@ vec4 applyTransform(const in StateData state, vec4 pos) {
   pos.xyz = mix(pos.xyz, pos.xyz / pos.w, notEqual(state.vtx_fmt.xyz, vec3(0.0)));
   pos.xy *= state.window_scale.xy;
   return pos;
-};
+}
 void processVertex(const in StateData state);
 void main() {
   gl_Position = vec4(0.0, 0.0, 0.0, 1.0);

--- a/src/xenia/ui/gl/gl_context.cc
+++ b/src/xenia/ui/gl/gl_context.cc
@@ -287,8 +287,8 @@ void GLContext::AssertExtensionsPresent() {
       reinterpret_cast<const char*>(glGetString(GL_SHADING_LANGUAGE_VERSION));
   std::string glsl_version(glsl_version_raw);
   if (glsl_version.find("4.50") != 0) {
-    XELOGW("GLSL version reported as %s; you may have a bad time!",
-           glsl_version_raw);
+    FatalGLError("OpenGL GLSL version 4.50 is required.");
+    return;
   }
 
   if (!GLEW_ARB_bindless_texture || !glMakeTextureHandleResidentARB) {


### PR DESCRIPTION
2 things:
1- minor syntax fix
2- changes from commit f75a4cab0e2ec6d7acde47bea38fbd994994ac54 introduced usage of ```mix(vec4, vec4, bool)``` which is a GLSL 4.50 function. The shaders do not compile on AMD anymore, so make it a failure to not support GLSL 4.50 (like it was before). Also, this probably means that issue #416 is not caused by incomplete GLSL support...