### PR TITLE
Trace Viewer Zoomed View / Fix Alpha Test

### DIFF
--- a/src/xenia/gpu/trace_viewer.cc
+++ b/src/xenia/gpu/trace_viewer.cc
@@ -639,8 +639,8 @@ void TraceViewer::DrawTextureInfo(
 
   ImGui::Columns(2);
   ImVec2 button_size(256, 256);
-  if (ImGui::ImageButton(ImTextureID(texture), button_size, ImVec2(0, 0),
-                         ImVec2(1, 1))) {
+  if (ImGui::ImageButton(ImTextureID(texture | ui::ImGuiDrawer::kIgnoreAlpha),
+                         button_size, ImVec2(0, 0), ImVec2(1, 1))) {
     // show viewer
   }
   ImGui::NextColumn();
@@ -1316,9 +1316,9 @@ void TraceViewer::DrawStateUI() {
         ImVec2 button_size(256, 256);
         ImTextureID tex = 0;
         if (write_mask) {
-          auto color_target = GetColorRenderTarget(
-              i, surface_pitch, surface_msaa, color_base, color_format);
-          tex = ImTextureID(color_target);
+          auto color_target = GetColorRenderTarget(surface_pitch, surface_msaa,
+                                                   color_base, color_format);
+          tex = ImTextureID(color_target | ui::ImGuiDrawer::kIgnoreAlpha);
           if (ImGui::ImageButton(tex, button_size, ImVec2(0, 0),
                                  ImVec2(1, 1))) {
             // show viewer
@@ -1407,8 +1407,9 @@ void TraceViewer::DrawStateUI() {
 
       auto button_pos = ImGui::GetCursorScreenPos();
       ImVec2 button_size(256, 256);
-      ImGui::ImageButton(ImTextureID(depth_target), button_size, ImVec2(0, 0),
-                         ImVec2(1, 1));
+      ImGui::ImageButton(
+          ImTextureID(depth_target | ui::ImGuiDrawer::kIgnoreAlpha),
+          button_size, ImVec2(0, 0), ImVec2(1, 1));
       if (ImGui::IsItemHovered()) {
         ImGui::BeginTooltip();
 

--- a/src/xenia/ui/gl/gl_immediate_drawer.cc
+++ b/src/xenia/ui/gl/gl_immediate_drawer.cc
@@ -270,6 +270,16 @@ void GLImmediateDrawer::End() {
   }
 }
 
+void GLImmediateDrawer::EnableAlphaTest(bool enable) {
+  if (enable) {
+    glEnablei(GL_BLEND, 0);
+    glBlendEquationi(0, GL_FUNC_ADD);
+    glBlendFunci(0, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+  } else {
+    glDisablei(GL_BLEND, 0);
+  }
+}
+
 }  // namespace gl
 }  // namespace ui
 }  // namespace xe

--- a/src/xenia/ui/gl/gl_immediate_drawer.cc
+++ b/src/xenia/ui/gl/gl_immediate_drawer.cc
@@ -228,6 +228,14 @@ void GLImmediateDrawer::Draw(const ImmediateDraw& draw) {
     glDisable(GL_SCISSOR_TEST);
   }
 
+  if (draw.alpha_blend) {
+    glEnablei(GL_BLEND, 0);
+    glBlendEquationi(0, GL_FUNC_ADD);
+    glBlendFunci(0, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+  } else {
+    glDisablei(GL_BLEND, 0);
+  }
+
   if (draw.texture_handle) {
     glBindTextureUnit(0, static_cast<GLuint>(draw.texture_handle));
   } else {
@@ -267,16 +275,6 @@ void GLImmediateDrawer::End() {
 
   if (!was_current_) {
     graphics_context_->ClearCurrent();
-  }
-}
-
-void GLImmediateDrawer::EnableAlphaTest(bool enable) {
-  if (enable) {
-    glEnablei(GL_BLEND, 0);
-    glBlendEquationi(0, GL_FUNC_ADD);
-    glBlendFunci(0, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-  } else {
-    glDisablei(GL_BLEND, 0);
   }
 }
 

--- a/src/xenia/ui/gl/gl_immediate_drawer.h
+++ b/src/xenia/ui/gl/gl_immediate_drawer.h
@@ -37,8 +37,6 @@ class GLImmediateDrawer : public ImmediateDrawer {
   void EndDrawBatch() override;
   void End() override;
 
-  void EnableAlphaTest(bool enable);
-
  private:
   void InitializeShaders();
 

--- a/src/xenia/ui/gl/gl_immediate_drawer.h
+++ b/src/xenia/ui/gl/gl_immediate_drawer.h
@@ -37,6 +37,8 @@ class GLImmediateDrawer : public ImmediateDrawer {
   void EndDrawBatch() override;
   void End() override;
 
+  void EnableAlphaTest(bool enable);
+
  private:
   void InitializeShaders();
 

--- a/src/xenia/ui/imgui_drawer.cc
+++ b/src/xenia/ui/imgui_drawer.cc
@@ -203,26 +203,21 @@ void ImGuiDrawer::RenderDrawLists(ImDrawData* data) {
     for (int j = 0; j < cmd_list->CmdBuffer.size(); ++j) {
       const auto& cmd = cmd_list->CmdBuffer[j];
 
-      if (reinterpret_cast<uintptr_t>(cmd.TextureId) & kIgnoreAlpha) {
-        drawer->EnableAlphaTest(false);
-      }
-
       ImmediateDraw draw;
       draw.primitive_type = ImmediatePrimitiveType::kTriangles;
       draw.count = cmd.ElemCount;
       draw.index_offset = index_offset;
       draw.texture_handle =
           reinterpret_cast<uintptr_t>(cmd.TextureId) & 0xFFFFFFFF;
+      draw.alpha_blend =
+          reinterpret_cast<uintptr_t>(cmd.TextureId) & kIgnoreAlpha ? false
+                                                                    : true;
       draw.scissor = true;
       draw.scissor_rect[0] = static_cast<int>(cmd.ClipRect.x);
       draw.scissor_rect[1] = static_cast<int>(height - cmd.ClipRect.w);
       draw.scissor_rect[2] = static_cast<int>(cmd.ClipRect.z - cmd.ClipRect.x);
       draw.scissor_rect[3] = static_cast<int>(cmd.ClipRect.w - cmd.ClipRect.y);
       drawer->Draw(draw);
-
-      if (reinterpret_cast<uintptr_t>(cmd.TextureId) & kIgnoreAlpha) {
-        drawer->EnableAlphaTest(true);
-      }
 
       index_offset += cmd.ElemCount;
     }

--- a/src/xenia/ui/imgui_drawer.cc
+++ b/src/xenia/ui/imgui_drawer.cc
@@ -203,17 +203,26 @@ void ImGuiDrawer::RenderDrawLists(ImDrawData* data) {
     for (int j = 0; j < cmd_list->CmdBuffer.size(); ++j) {
       const auto& cmd = cmd_list->CmdBuffer[j];
 
+      if (reinterpret_cast<uintptr_t>(cmd.TextureId) & kIgnoreAlpha) {
+        drawer->EnableAlphaTest(false);
+      }
+
       ImmediateDraw draw;
       draw.primitive_type = ImmediatePrimitiveType::kTriangles;
       draw.count = cmd.ElemCount;
       draw.index_offset = index_offset;
-      draw.texture_handle = reinterpret_cast<uintptr_t>(cmd.TextureId);
+      draw.texture_handle =
+          reinterpret_cast<uintptr_t>(cmd.TextureId) & 0xFFFFFFFF;
       draw.scissor = true;
       draw.scissor_rect[0] = static_cast<int>(cmd.ClipRect.x);
       draw.scissor_rect[1] = static_cast<int>(height - cmd.ClipRect.w);
       draw.scissor_rect[2] = static_cast<int>(cmd.ClipRect.z - cmd.ClipRect.x);
       draw.scissor_rect[3] = static_cast<int>(cmd.ClipRect.w - cmd.ClipRect.y);
       drawer->Draw(draw);
+
+      if (reinterpret_cast<uintptr_t>(cmd.TextureId) & kIgnoreAlpha) {
+        drawer->EnableAlphaTest(true);
+      }
 
       index_offset += cmd.ElemCount;
     }

--- a/src/xenia/ui/imgui_drawer.h
+++ b/src/xenia/ui/imgui_drawer.h
@@ -35,6 +35,8 @@ class ImGuiDrawer : public WindowListener {
 
   ImGuiIO& GetIO();
 
+  static const uint64_t kIgnoreAlpha = (1ull << 32);
+
  protected:
   void Initialize();
   void SetupFont();

--- a/src/xenia/ui/immediate_drawer.h
+++ b/src/xenia/ui/immediate_drawer.h
@@ -87,6 +87,9 @@ struct ImmediateDraw {
   bool scissor = false;
   // Scissoring region in framebuffer pixels as (x, y, w, h).
   int scissor_rect[4] = {0};
+
+  // Blends this draw with the background depending on its alpha (if true).
+  bool alpha_blend = true;
 };
 
 class ImmediateDrawer {
@@ -112,8 +115,6 @@ class ImmediateDrawer {
   virtual void EndDrawBatch() = 0;
   // Ends drawing in immediate mode and flushes contents.
   virtual void End() = 0;
-
-  virtual void EnableAlphaTest(bool enable) = 0;
 
  protected:
   ImmediateDrawer(GraphicsContext* graphics_context)

--- a/src/xenia/ui/immediate_drawer.h
+++ b/src/xenia/ui/immediate_drawer.h
@@ -113,6 +113,8 @@ class ImmediateDrawer {
   // Ends drawing in immediate mode and flushes contents.
   virtual void End() = 0;
 
+  virtual void EnableAlphaTest(bool enable) = 0;
+
  protected:
   ImmediateDrawer(GraphicsContext* graphics_context)
       : graphics_context_(graphics_context) {}


### PR DESCRIPTION
* Zoomed views for color targets / depth targets
* Fixes invisible images due to their alpha.
* Also correctly flags the alpha test as disabled/enabled