### PR TITLE
Fix usage of mix in fragment shader

### DIFF
--- a/src/xenia/gpu/glsl_shader_translator.cc
+++ b/src/xenia/gpu/glsl_shader_translator.cc
@@ -360,7 +360,8 @@ void main() {
     // May need a usage map?
     for (int i = 0; i < kMaxInterpolators; i++) {
       EmitSource(
-          "    r[%d] = mix(r[%d], ps_param_gen, state.ps_param_gen == %d);\n",
+          "    r[%d] = mix(r[%d], ps_param_gen, bvec4(state.ps_param_gen == "
+          "%d));\n",
           i, i, i);
     }
 


### PR DESCRIPTION
The boolean value must be a vector too, where each bool component
selects whether the value of the output vector component is from the
first or the second source vector.