### PR TITLE
Expanded vec128 and VectorSub

### DIFF
--- a/src/xenia/base/vec128.h
+++ b/src/xenia/base/vec128.h
@@ -90,7 +90,8 @@ typedef struct alignas(16) vec128_s {
       uint32_t uz;
       uint32_t uw;
     };
-    float f32[4];
+	float f32[4];
+	double f64[2];
     int8_t i8[16];
     uint8_t u8[16];
     int16_t i16[8];

--- a/src/xenia/base/vec128.h
+++ b/src/xenia/base/vec128.h
@@ -90,8 +90,8 @@ typedef struct alignas(16) vec128_s {
       uint32_t uz;
       uint32_t uw;
     };
-	float f32[4];
-	double f64[2];
+    float f32[4];
+    double f64[2];
     int8_t i8[16];
     uint8_t u8[16];
     int16_t i16[8];

--- a/src/xenia/cpu/hir/value.cc
+++ b/src/xenia/cpu/hir/value.cc
@@ -1004,29 +1004,80 @@ void Value::VectorRol(Value* other, TypeName type) {
 }
 
 void Value::VectorSub(Value* other, TypeName type, bool is_unsigned,
-                      bool saturate) {
-  assert_true(this->type == VEC128_TYPE && other->type == VEC128_TYPE);
-  switch (type) {
-    case INT32_TYPE:
-      for (int i = 0; i < 4; i++) {
-        if (is_unsigned) {
-          if (saturate) {
-            assert_always();
-          } else {
-            constant.v128.u32[i] -= other->constant.v128.u32[i];
-          }
-        } else {
-          if (saturate) {
-            assert_always();
-          } else {
-            constant.v128.i32[i] -= other->constant.v128.i32[i];
-          }
-        }
-      }
-    default:
-      assert_unhandled_case(type);
-      break;
-  }
+	bool saturate) {
+	assert_true(this->type == VEC128_TYPE && other->type == VEC128_TYPE);
+	switch (type) {
+	case FLOAT32_TYPE:
+		if (saturate) assert_always();
+		else
+		{
+			constant.v128.x -= other->constant.v128.x;
+			constant.v128.y -= other->constant.v128.y;
+			constant.v128.z -= other->constant.v128.z;
+			constant.v128.w -= other->constant.v128.w;
+		}
+		break;
+	case INT32_TYPE:
+		if (saturate) assert_always();
+		else
+		{
+			for (int i = 0; i < 4; i++)
+			{
+				if (is_unsigned) constant.v128.u32[i] -= other->constant.v128.u32[i];
+				else constant.v128.i32[i] -= other->constant.v128.i32[i];
+			}
+		}
+		break;
+	case FLOAT64_TYPE:
+		if (saturate) assert_always();
+		else
+		{
+			constant.v128.f64[0] -= other->constant.v128.f64[0];
+			constant.v128.f64[1] -= other->constant.v128.f64[1];
+		}
+		break;
+	case INT8_TYPE:
+		if (saturate) assert_always();
+		else
+		{
+			for (int i = 0; i < 16; i++)
+			{
+				if (is_unsigned) constant.v128.u8[i] -= other->constant.v128.u8[i];
+				else constant.v128.i8[i] -= other->constant.v128.i8[i];
+			}
+		}
+		break;
+	case INT16_TYPE:
+		if (saturate) assert_always();
+		else
+		{
+			for (int i = 0; i < 9; i++)
+			{
+				if (is_unsigned) constant.v128.u16[i] -= other->constant.v128.u16[i];
+				else constant.v128.i16[i] -= other->constant.v128.i16[i];
+			}
+		}
+		break;
+	case INT64_TYPE:
+		if (saturate) assert_always();
+		else
+		{
+			if (is_unsigned)
+			{
+				constant.v128.u64[0] -= other->constant.v128.u64[0];
+				constant.v128.u64[1] -= other->constant.v128.u64[1];
+			}
+			else
+			{
+				constant.v128.i64[0] -= other->constant.v128.i64[0];
+				constant.v128.i64[1] -= other->constant.v128.i64[1];
+			}
+		}
+		break;
+	default:
+		assert_unhandled_case(type);
+		break;
+	}
 }
 
 void Value::ByteSwap() {

--- a/src/xenia/cpu/hir/value.cc
+++ b/src/xenia/cpu/hir/value.cc
@@ -1,11 +1,11 @@
 /**
- ******************************************************************************
- * Xenia : Xbox 360 Emulator Research Project                                 *
- ******************************************************************************
- * Copyright 2013 Ben Vanik. All rights reserved.                             *
- * Released under the BSD license - see LICENSE in the root for more details. *
- ******************************************************************************
- */
+******************************************************************************
+* Xenia : Xbox 360 Emulator Research Project                                 *
+******************************************************************************
+* Copyright 2013 Ben Vanik. All rights reserved.                             *
+* Released under the BSD license - see LICENSE in the root for more details. *
+******************************************************************************
+*/
 
 #include "xenia/cpu/hir/value.h"
 
@@ -1004,80 +1004,80 @@ void Value::VectorRol(Value* other, TypeName type) {
 }
 
 void Value::VectorSub(Value* other, TypeName type, bool is_unsigned,
-	bool saturate) {
-	assert_true(this->type == VEC128_TYPE && other->type == VEC128_TYPE);
-	switch (type) {
-	case FLOAT32_TYPE:
-		if (saturate) assert_always();
-		else
-		{
-			constant.v128.x -= other->constant.v128.x;
-			constant.v128.y -= other->constant.v128.y;
-			constant.v128.z -= other->constant.v128.z;
-			constant.v128.w -= other->constant.v128.w;
-		}
-		break;
-	case INT32_TYPE:
-		if (saturate) assert_always();
-		else
-		{
-			for (int i = 0; i < 4; i++)
-			{
-				if (is_unsigned) constant.v128.u32[i] -= other->constant.v128.u32[i];
-				else constant.v128.i32[i] -= other->constant.v128.i32[i];
-			}
-		}
-		break;
-	case FLOAT64_TYPE:
-		if (saturate) assert_always();
-		else
-		{
-			constant.v128.f64[0] -= other->constant.v128.f64[0];
-			constant.v128.f64[1] -= other->constant.v128.f64[1];
-		}
-		break;
-	case INT8_TYPE:
-		if (saturate) assert_always();
-		else
-		{
-			for (int i = 0; i < 16; i++)
-			{
-				if (is_unsigned) constant.v128.u8[i] -= other->constant.v128.u8[i];
-				else constant.v128.i8[i] -= other->constant.v128.i8[i];
-			}
-		}
-		break;
-	case INT16_TYPE:
-		if (saturate) assert_always();
-		else
-		{
-			for (int i = 0; i < 9; i++)
-			{
-				if (is_unsigned) constant.v128.u16[i] -= other->constant.v128.u16[i];
-				else constant.v128.i16[i] -= other->constant.v128.i16[i];
-			}
-		}
-		break;
-	case INT64_TYPE:
-		if (saturate) assert_always();
-		else
-		{
-			if (is_unsigned)
-			{
-				constant.v128.u64[0] -= other->constant.v128.u64[0];
-				constant.v128.u64[1] -= other->constant.v128.u64[1];
-			}
-			else
-			{
-				constant.v128.i64[0] -= other->constant.v128.i64[0];
-				constant.v128.i64[1] -= other->constant.v128.i64[1];
-			}
-		}
-		break;
-	default:
-		assert_unhandled_case(type);
-		break;
-	}
+                      bool saturate) {
+  assert_true(this->type == VEC128_TYPE && other->type == VEC128_TYPE);
+  switch (type) {
+    case FLOAT32_TYPE:
+      if (saturate)
+        assert_always();
+      else {
+        constant.v128.x -= other->constant.v128.x;
+        constant.v128.y -= other->constant.v128.y;
+        constant.v128.z -= other->constant.v128.z;
+        constant.v128.w -= other->constant.v128.w;
+      }
+      break;
+    case INT32_TYPE:
+      if (saturate)
+        assert_always();
+      else {
+        for (int i = 0; i < 4; i++) {
+          if (is_unsigned)
+            constant.v128.u32[i] -= other->constant.v128.u32[i];
+          else
+            constant.v128.i32[i] -= other->constant.v128.i32[i];
+        }
+      }
+      break;
+    case FLOAT64_TYPE:
+      if (saturate)
+        assert_always();
+      else {
+        constant.v128.f64[0] -= other->constant.v128.f64[0];
+        constant.v128.f64[1] -= other->constant.v128.f64[1];
+      }
+      break;
+    case INT8_TYPE:
+      if (saturate)
+        assert_always();
+      else {
+        for (int i = 0; i < 16; i++) {
+          if (is_unsigned)
+            constant.v128.u8[i] -= other->constant.v128.u8[i];
+          else
+            constant.v128.i8[i] -= other->constant.v128.i8[i];
+        }
+      }
+      break;
+    case INT16_TYPE:
+      if (saturate)
+        assert_always();
+      else {
+        for (int i = 0; i < 8; i++) {
+          if (is_unsigned)
+            constant.v128.u16[i] -= other->constant.v128.u16[i];
+          else
+            constant.v128.i16[i] -= other->constant.v128.i16[i];
+        }
+      }
+      break;
+    case INT64_TYPE:
+      if (saturate)
+        assert_always();
+      else {
+        if (is_unsigned) {
+          constant.v128.u64[0] -= other->constant.v128.u64[0];
+          constant.v128.u64[1] -= other->constant.v128.u64[1];
+        } else {
+          constant.v128.i64[0] -= other->constant.v128.i64[0];
+          constant.v128.i64[1] -= other->constant.v128.i64[1];
+        }
+      }
+      break;
+    default:
+      assert_unhandled_case(type);
+      break;
+  }
 }
 
 void Value::ByteSwap() {


### PR DESCRIPTION
Added double precision (f64) values to the vec128 structure
Added cases for all formats of data for vector subtraction in the
Value::VectorSub function

NOTE: Unsure what the saturate function is for however maintained
original functionality