### PR TITLE
third_party: vulkan: loader: fix Linux build

### DIFF
--- a/third_party/vulkan/loader/premake5.lua
+++ b/third_party/vulkan/loader/premake5.lua
@@ -2,7 +2,7 @@ group("third_party")
 project("vulkan-loader")
   uuid("07d77359-1618-43e6-8a4a-0ee9ddc5fa6a")
   kind("StaticLib")
-  language("C++")
+  language("C")
 
   defines({
     "_LIB",
@@ -22,4 +22,11 @@ project("vulkan-loader")
     characterset("MBCS")
     defines({
       "VK_USE_PLATFORM_WIN32_KHR",
+    })
+  filter("platforms:not Windows")
+    removefiles("dirent_on_windows.c")
+  filter("platforms:Linux")
+    defines({
+      [[SYSCONFDIR="\"/etc\""]],
+      [[DATADIR="\"/usr/share\""]],
     })


### PR DESCRIPTION
* Remove Win32 dirent implementation from Linux build
* Fix a bunch of clang warnings
* Add default paths that would otherwise be passed from CMake