### PR TITLE
Linux + clang build fixes

### DIFF
--- a/src/xenia/cpu/compiler/passes/constant_propagation_pass.cc
+++ b/src/xenia/cpu/compiler/passes/constant_propagation_pass.cc
@@ -10,6 +10,7 @@
 #include "xenia/cpu/compiler/passes/constant_propagation_pass.h"
 
 #include <gflags/gflags.h>
+#include <cmath>
 
 #include "xenia/base/assert.h"
 #include "xenia/base/profiling.h"
@@ -303,10 +304,10 @@ bool ConstantPropagationPass::Run(HIRBuilder* builder) {
         case OPCODE_IS_NAN:
           if (i->src1.value->IsConstant()) {
             if (i->src1.value->type == FLOAT32_TYPE &&
-                isnan(i->src1.value->constant.f32)) {
+                std::isnan(i->src1.value->constant.f32)) {
               v->set_constant(uint8_t(1));
             } else if (i->src1.value->type == FLOAT64_TYPE &&
-                       isnan(i->src1.value->constant.f64)) {
+                       std::isnan(i->src1.value->constant.f64)) {
               v->set_constant(uint8_t(1));
             } else {
               v->set_constant(uint8_t(0));

--- a/src/xenia/gpu/command_processor.cc
+++ b/src/xenia/gpu/command_processor.cc
@@ -10,6 +10,7 @@
 #include "xenia/gpu/command_processor.h"
 
 #include <algorithm>
+#include <cmath>
 
 #include "xenia/base/byte_stream.h"
 #include "xenia/base/logging.h"

--- a/src/xenia/gpu/spirv_shader_translator.cc
+++ b/src/xenia/gpu/spirv_shader_translator.cc
@@ -241,8 +241,8 @@ void SpirvShaderTranslator::StartTranslation() {
           case VertexFormat::k_32_32:
             if (is_integer) {
               attrib_type = is_signed ? vec2_int_type_ : vec2_uint_type_;
-              break;
             }
+            break;
           case VertexFormat::k_16_16_FLOAT:
           case VertexFormat::k_32_32_FLOAT:
             attrib_type = vec2_float_type_;
@@ -258,8 +258,8 @@ void SpirvShaderTranslator::StartTranslation() {
           case VertexFormat::k_32_32_32_32:
             if (is_integer) {
               attrib_type = is_signed ? vec4_int_type_ : vec4_uint_type_;
-              break;
             }
+            break;
           case VertexFormat::k_16_16_16_16_FLOAT:
           case VertexFormat::k_32_32_32_32_FLOAT:
             attrib_type = vec4_float_type_;
@@ -1123,8 +1123,10 @@ void SpirvShaderTranslator::ProcessVertexFetchInstruction(
 
   switch (instr.attributes.data_format) {
     case VertexFormat::k_8_8_8_8:
+    case VertexFormat::k_2_10_10_10:
     case VertexFormat::k_16_16:
     case VertexFormat::k_16_16_16_16:
+    case VertexFormat::k_16_16_FLOAT:
     case VertexFormat::k_16_16_16_16_FLOAT:
     case VertexFormat::k_32:
     case VertexFormat::k_32_32:
@@ -1211,6 +1213,9 @@ void SpirvShaderTranslator::ProcessVertexFetchInstruction(
           vec3_float_type_,
           std::vector<Id>({components[0], components[1], components[2]}));
     } break;
+
+    case VertexFormat::kUndefined:
+      break;
   }
 
   // Convert any integers to floats.

--- a/src/xenia/gpu/spirv_shader_translator.cc
+++ b/src/xenia/gpu/spirv_shader_translator.cc
@@ -11,6 +11,7 @@
 
 #include <gflags/gflags.h>
 
+#include <cfloat>
 #include <cstring>
 
 #include "xenia/base/logging.h"

--- a/src/xenia/gpu/spirv_shader_translator.h
+++ b/src/xenia/gpu/spirv_shader_translator.h
@@ -96,9 +96,10 @@ class SpirvShaderTranslator : public ShaderTranslator {
                          bool is_signed);
 
   // Creates a call to the given GLSL intrinsic.
-  spv::Id SpirvShaderTranslator::CreateGlslStd450InstructionCall(
-      spv::Decoration precision, spv::Id result_type,
-      spv::GLSLstd450 instruction_ordinal, std::vector<spv::Id> args);
+  spv::Id CreateGlslStd450InstructionCall(spv::Decoration precision,
+                                          spv::Id result_type,
+                                          spv::GLSLstd450 instruction_ordinal,
+                                          std::vector<spv::Id> args);
 
   // Loads an operand into a value.
   // The value returned will be in the form described in the operand (number of

--- a/src/xenia/gpu/texture_info.cc
+++ b/src/xenia/gpu/texture_info.cc
@@ -10,6 +10,7 @@
 #include "xenia/gpu/texture_info.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstring>
 
 #include "third_party/xxhash/xxhash.h"

--- a/src/xenia/gpu/trace_viewer.cc
+++ b/src/xenia/gpu/trace_viewer.cc
@@ -404,7 +404,7 @@ int TraceViewer::RecursiveDrawCommandBufferUI(
         }
 
         ImGui::PushID(int(i));
-        if (ImGui::TreeNode((void*)0, "Indirect Buffer %d", i)) {
+        if (ImGui::TreeNode((void*)0, "Indirect Buffer %" PRIu64, i)) {
           ImGui::Indent();
           auto id = RecursiveDrawCommandBufferUI(
               frame, buffer->commands[i].command_subtree.get());
@@ -1563,7 +1563,7 @@ void TraceViewer::DrawStateUI() {
       vertices.resize(size / 4);
       QueryVSOutput(vertices.data(), size);
 
-      ImGui::Text("%d output vertices", vertices.size() / 4);
+      ImGui::Text("%" PRIu64 " output vertices", vertices.size() / 4);
       ImGui::SameLine();
       static bool normalize = false;
       ImGui::Checkbox("Normalize", &normalize);

--- a/third_party/llvm/include/llvm/Support/MathExtras.h
+++ b/third_party/llvm/include/llvm/Support/MathExtras.h
@@ -18,8 +18,9 @@
 #ifdef IGNORED_LLVM_XENIA
 #include "llvm/Support/SwapByteOrder.h"
 #endif  // IGNORED_LLVM_XENIA
-#include "llvm/Support/type_traits.h"
+#include <cmath>
 #include <cstring>
+#include "llvm/Support/type_traits.h"
 
 #ifdef _MSC_VER
 #include <intrin.h>


### PR DESCRIPTION
* Fixed missing includes (cmath, cfloat)
* Added const specifiers to some functions in SPIR-V builder so there aren't any lvalue-references to temporary objects in spirv_shader_translator
* Fixed crossed variable initialization
* xb format did quite a few changes

FTR I was building with clang 3.8.0 on Fedora 25