### PR TITLE
Various fixes

### DIFF
--- a/src/xenia/cpu/xex_module.cc
+++ b/src/xenia/cpu/xex_module.cc
@@ -237,39 +237,44 @@ bool XexModule::Load(const std::string& name, const std::string& path,
   // Add all imports (variables/functions).
   xex2_opt_import_libraries* opt_import_header = nullptr;
   GetOptHeader(XEX_HEADER_IMPORT_LIBRARIES, &opt_import_header);
-  assert_not_null(opt_import_header);
 
-  // FIXME: Don't know if 32 is the actual limit, but haven't seen more than 2.
-  const char* string_table[32];
-  std::memset(string_table, 0, sizeof(string_table));
-  size_t max_string_table_index = 0;
+  if (opt_import_header == nullptr) {
+    XELOGW("WARNING: No import header found when loading module %s!",
+           path_.c_str());
+  } else {
+    // FIXME: Don't know if 32 is the actual limit, but haven't seen more than
+    // 2.
+    const char* string_table[32];
+    std::memset(string_table, 0, sizeof(string_table));
+    size_t max_string_table_index = 0;
 
-  // Parse the string table
-  for (size_t i = 0; i < opt_import_header->string_table_size;
-       ++max_string_table_index) {
-    assert_true(max_string_table_index < xe::countof(string_table));
-    const char* str = opt_import_header->string_table + i;
+    // Parse the string table
+    for (size_t i = 0; i < opt_import_header->string_table_size;
+         ++max_string_table_index) {
+      assert_true(max_string_table_index < xe::countof(string_table));
+      const char* str = opt_import_header->string_table + i;
 
-    string_table[max_string_table_index] = str;
-    i += std::strlen(str) + 1;
+      string_table[max_string_table_index] = str;
+      i += std::strlen(str) + 1;
 
-    // Padding
-    if ((i % 4) != 0) {
-      i += 4 - (i % 4);
+      // Padding
+      if ((i % 4) != 0) {
+        i += 4 - (i % 4);
+      }
     }
-  }
 
-  auto libraries_ptr = reinterpret_cast<uint8_t*>(opt_import_header) +
-                       opt_import_header->string_table_size + 12;
-  uint32_t library_offset = 0;
-  uint32_t library_count = opt_import_header->library_count;
-  for (uint32_t i = 0; i < library_count; i++) {
-    auto library =
-        reinterpret_cast<xex2_import_library*>(libraries_ptr + library_offset);
-    size_t library_name_index = library->name_index & 0xFF;
-    assert_true(library_name_index < max_string_table_index);
-    SetupLibraryImports(string_table[library_name_index], library);
-    library_offset += library->size;
+    auto libraries_ptr = reinterpret_cast<uint8_t*>(opt_import_header) +
+                         opt_import_header->string_table_size + 12;
+    uint32_t library_offset = 0;
+    uint32_t library_count = opt_import_header->library_count;
+    for (uint32_t i = 0; i < library_count; i++) {
+      auto library = reinterpret_cast<xex2_import_library*>(libraries_ptr +
+                                                            library_offset);
+      size_t library_name_index = library->name_index & 0xFF;
+      assert_true(library_name_index < max_string_table_index);
+      SetupLibraryImports(string_table[library_name_index], library);
+      library_offset += library->size;
+    }
   }
 
   // Find __savegprlr_* and __restgprlr_* and the others.

--- a/src/xenia/memory.cc
+++ b/src/xenia/memory.cc
@@ -853,7 +853,6 @@ bool BaseHeap::AllocRange(uint32_t low_address, uint32_t high_address,
   if (start_page_number == UINT_MAX || end_page_number == UINT_MAX) {
     // Out of memory.
     XELOGE("BaseHeap::Alloc failed to find contiguous range");
-    assert_always("Heap exhausted!");
     return false;
   }
 


### PR DESCRIPTION
These are fixes for some small things I came across:

- Some games load code from separate .dlls which do not have import headers. I added a check for this and a warning is written to the log.
- Games may intentionally ask for too much memory (see PR #376) but there is an assert every time it happens, making it difficult to do other debugging. This assert is removed here.
- Some games have enormous shaders (~1000 lines disassembled) which were causing an overflow in the logger format buffer.