### PR TITLE
Ringbuffer init fix

### DIFF
--- a/src/xenia/gpu/command_processor.cc
+++ b/src/xenia/gpu/command_processor.cc
@@ -229,6 +229,7 @@ bool CommandProcessor::SetupContext() { return true; }
 void CommandProcessor::ShutdownContext() { context_.reset(); }
 
 void CommandProcessor::InitializeRingBuffer(uint32_t ptr, uint32_t log2_size) {
+  read_ptr_index_ = 0;
   primary_buffer_ptr_ = ptr;
   primary_buffer_size_ = uint32_t(std::pow(2u, log2_size));
 }

--- a/src/xenia/gpu/vulkan/pipeline_cache.cc
+++ b/src/xenia/gpu/vulkan/pipeline_cache.cc
@@ -1074,6 +1074,7 @@ PipelineCache::UpdateStatus PipelineCache::UpdateInputAssemblyState(
   }
   // TODO(benvanik): no way to specify in Vulkan?
   assert_true(regs.multi_prim_ib_reset_index == 0xFFFF ||
+              regs.multi_prim_ib_reset_index == 0xFFFFFF ||
               regs.multi_prim_ib_reset_index == 0xFFFFFFFF);
   // glPrimitiveRestartIndex(regs.multi_prim_ib_reset_index);
 


### PR DESCRIPTION
Must reset read_ptr_index_ in CommandProcessor::InitializeRingBuffer becaue a game can initialize the ring buffer multiple times.
Left the new condition on the assertion as the value 0xFFFFFF seems to acceptable and it's preventing 4B4F07FE to go ahead.