### PR TITLE
Specify python2 in xenia-build

### DIFF
--- a/xenia-build
+++ b/xenia-build
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright 2015 Ben Vanik. All Rights Reserved.
 


### PR DESCRIPTION
Otherwise it breaks on Arch Linux