### PR TITLE
[RFC] Build against Windows 10 SDK

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -185,6 +185,13 @@ solution("xenia")
     platforms({"Linux"})
   elseif os.is("windows") then
     platforms({"Windows"})
+
+	-- Determine the Windows SDK version. Adapted from https://github.com/premake/premake-core/issues/651
+	if os.getversion().majorversion == 10 then
+		local win10SDK = os.getWindowsRegistry( "HKLM:SOFTWARE\\Wow6432Node\\Microsoft\\Microsoft SDKs\\Windows\\v10.0\\ProductVersion" )
+		-- It needs an extra ".0" to be recognized by VS
+		if win10SDK ~= nil then systemversion( win10SDK .. ".0" ) end
+	end
   end
   configurations({"Checked", "Debug", "Release"})
 

--- a/premake5.lua
+++ b/premake5.lua
@@ -7,7 +7,7 @@ objdir(build_obj)
 
 -- Define an ARCH variable
 -- Only use this to enable architecture-specific functionality.
-if os.is("linux") then
+if os.istarget("linux") then
   ARCH = os.outputof("uname -p")
 else
   ARCH = "unknown"
@@ -181,9 +181,9 @@ solution("xenia")
   uuid("931ef4b0-6170-4f7a-aaf2-0fece7632747")
   startproject("xenia-app")
   architecture("x86_64")
-  if os.is("linux") then
+  if os.istarget("linux") then
     platforms({"Linux"})
-  elseif os.is("windows") then
+  elseif os.istarget("windows") then
     platforms({"Windows"})
 
 	-- Determine the Windows SDK version. Adapted from https://github.com/premake/premake-core/issues/651
@@ -229,7 +229,7 @@ solution("xenia")
   include("src/xenia/ui/vulkan")
   include("src/xenia/vfs")
 
-  if os.is("windows") then
+  if os.istarget("windows") then
     include("src/xenia/apu/xaudio2")
     include("src/xenia/hid/winkey")
     include("src/xenia/hid/xinput")

--- a/src/xenia/app/premake5.lua
+++ b/src/xenia/app/premake5.lua
@@ -27,9 +27,6 @@ project("xenia-app")
     "xenia-ui-gl",
     "xenia-vfs",
   })
-  flags({
-    "WinMain",  -- Use WinMain instead of main.
-  })
   defines({
   })
   includedirs({

--- a/src/xenia/gpu/gl4/premake5.lua
+++ b/src/xenia/gpu/gl4/premake5.lua
@@ -50,9 +50,6 @@ project("xenia-gpu-gl4-trace-viewer")
     "xenia-ui-gl",
     "xenia-vfs",
   })
-  flags({
-    "WinMain",  -- Use WinMain instead of main.
-  })
   defines({
     "GLEW_STATIC=1",
     "GLEW_MX=1",

--- a/src/xenia/gpu/vulkan/premake5.lua
+++ b/src/xenia/gpu/vulkan/premake5.lua
@@ -53,9 +53,6 @@ project("xenia-gpu-vulkan-trace-viewer")
     "xenia-ui-vulkan",
     "xenia-vfs",
   })
-  flags({
-    "WinMain",  -- Use WinMain instead of main.
-  })
   defines({
   })
   includedirs({

--- a/src/xenia/hid/premake5.lua
+++ b/src/xenia/hid/premake5.lua
@@ -32,9 +32,6 @@ project("xenia-hid-demo")
     "xenia-ui",
     "xenia-ui-gl",
   })
-  flags({
-    "WinMain",  -- Use WinMain instead of main.
-  })
   defines({
     "GLEW_STATIC=1",
     "GLEW_MX=1",

--- a/src/xenia/hid/xinput/xinput_input_driver.cc
+++ b/src/xenia/hid/xinput/xinput_input_driver.cc
@@ -21,11 +21,9 @@ namespace hid {
 namespace xinput {
 
 XInputInputDriver::XInputInputDriver(xe::ui::Window* window)
-    : InputDriver(window) {
-  XInputEnable(TRUE);
-}
+    : InputDriver(window) { }
 
-XInputInputDriver::~XInputInputDriver() { XInputEnable(FALSE); }
+XInputInputDriver::~XInputInputDriver() { }
 
 X_STATUS XInputInputDriver::Setup() { return X_STATUS_SUCCESS; }
 

--- a/src/xenia/ui/file_picker_win.cc
+++ b/src/xenia/ui/file_picker_win.cc
@@ -36,10 +36,10 @@ class CDialogEventHandler : public IFileDialogEvents,
   IFACEMETHODIMP QueryInterface(REFIID riid, void** ppv) {
     static const QITAB qit[] = {
         {&__uuidof(IFileDialogEvents),
-         static_cast<int>(
+         static_cast<DWORD>(
              OFFSETOFCLASS(IFileDialogEvents, CDialogEventHandler))},
         {&__uuidof(IFileDialogControlEvents),
-         static_cast<int>(
+         static_cast<DWORD>(
              OFFSETOFCLASS(IFileDialogControlEvents, CDialogEventHandler))},
         {0},
     };

--- a/src/xenia/ui/gl/premake5.lua
+++ b/src/xenia/ui/gl/premake5.lua
@@ -34,9 +34,6 @@ project("xenia-ui-window-gl-demo")
     "xenia-ui",
     "xenia-ui-gl",
   })
-  flags({
-    "WinMain",  -- Use WinMain instead of main.
-  })
   defines({
     "GLEW_STATIC=1",
     "GLEW_MX=1",

--- a/src/xenia/ui/vulkan/premake5.lua
+++ b/src/xenia/ui/vulkan/premake5.lua
@@ -37,9 +37,6 @@ project("xenia-ui-window-vulkan-demo")
     "xenia-ui-spirv",
     "xenia-ui-vulkan",
   })
-  flags({
-    "WinMain",  -- Use WinMain instead of main.
-  })
   defines({
   })
   includedirs({

--- a/tools/build/scripts/build_paths.lua
+++ b/tools/build/scripts/build_paths.lua
@@ -7,7 +7,7 @@ build_tools = "tools/build"
 build_scripts = build_tools .. "/scripts"
 build_tools_src = build_tools .. "/src"
 
-if os.is("windows") then
+if os.istarget("windows") then
   platform_suffix = "win"
 else
   platform_suffix = "posix"

--- a/xenia-build
+++ b/xenia-build
@@ -328,7 +328,6 @@ def run_premake(target_os, action):
       os.path.join('tools', 'build', 'premake'),
       '--file=premake5.lua',
       '--os=%s' % (target_os),
-      '--cc=clang',
       '--test-suite-mode=combined',
       '--verbose',
       action,


### PR DESCRIPTION
Xenia currently builds on Windows 10, though premake defaults to using the Windows 8.1 SDK when generating VS projects. This PR allows for building Xenia with only a Windows 10 SDK installed.

There are two issues which need to be resolved before merging:

1. The code in this PR selects the most recent Windows 10 SDK on the system by looking at the registry. This is flexible but tends to imply that Xenia supports _all_ of the SDKs which may not be a good idea. Alternatively, we could pick a version and stick with it, though at the rate Microsoft puts out new Windows 10 builds it'd probably have to get bumped pretty frequently.

2. The premake version needs to be bumped. The binary at /tools/build/bin/premake5.exe is fairly out of date and doesn't report OS versions correctly (it reports Windows 10 as Windows 8 on my system). It could be replaced with a newer version or it could be deleted and the project could build premake from third_party/premake_core automatically. The premake build system needs some tweaks to work on Windows 10 (pretty much identical to what's been done here) but since Xenia has its own version of premake anyway this doesn't seem unreasonable. Building premake from source will probably be required for Linux builds so it may make sense to do it now.

Other things: 
- XInputEnable() has been deprecated under Windows 10, though from looking through the docs it doesn't seem like it was being used correctly here anyway. XInput still works fine with XInputEnable() being removed.
- flags({"WinMain"}) is no longer required for newer versions of premake, kind("WindowedApp") now implies this.

Comments welcome!