### PR TITLE
xboxkrnl_threading.cc: PVS-Studio: fixed return value.

### DIFF
--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_threading.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_threading.cc
@@ -1259,7 +1259,7 @@ pointer_result_t InterlockedPushEntrySList(
     new_hdr.depth = old_hdr.depth + 1;
     new_hdr.sequence = old_hdr.sequence + 1;
 
-    uint32_t old_head = old_hdr.next.next;
+    old_head = old_hdr.next.next;
     entry->next = old_hdr.next.next;
     new_hdr.next.next = entry.guest_address();
   } while (


### PR DESCRIPTION
We have found and fixed a bug using [PVS-Studio](https://www.viva64.com/en/pvs-studio/) analyzer. 

Return the variable _old_head_, which is always zero.

Analyzer warning: V561 It's probably better to assign value to 'old_head' variable than to declare it anew. Previous declaration: xboxkrnl_threading.cc, line 1256.