### PR TITLE
Xaudio2 bug fix

### DIFF
--- a/src/xenia/apu/xaudio2/xaudio2_audio_system.cc
+++ b/src/xenia/apu/xaudio2/xaudio2_audio_system.cc
@@ -44,7 +44,6 @@ void XAudio2AudioSystem::DestroyDriver(AudioDriver* driver) {
   assert_not_null(driver);
   auto xdriver = static_cast<XAudio2AudioDriver*>(driver);
   xdriver->Shutdown();
-  assert_not_null(xdriver);
   delete xdriver;
 }
 


### PR DESCRIPTION
Fixes #739. Call assert_not_null(xdriver) is not needed here. static_cast is not dynamic cast if the pointer is not null it will remain non-zero from what I understand. The assert_not_null(xdriver) should be removed.