### PR TITLE
Prevent race condition during emulator startup (issue #702)

### DIFF
--- a/src/xenia/app/emulator_window.cc
+++ b/src/xenia/app/emulator_window.cc
@@ -266,6 +266,8 @@ bool EmulatorWindow::Initialize() {
 
   window_->Resize(1280, 720);
 
+  window_->DisableMainMenu();
+
   return true;
 }
 

--- a/src/xenia/app/xenia_main.cc
+++ b/src/xenia/app/xenia_main.cc
@@ -178,6 +178,9 @@ int xenia_main(const std::vector<std::wstring>& args) {
     evt->Set();
   });
 
+  // Enable the main menu now that the emulator is properly loaded
+  emulator_window->window()->EnableMainMenu();
+
   // Grab path from the flag or unnamed argument.
   std::wstring path;
   if (!FLAGS_target.empty() || args.size() >= 2) {

--- a/src/xenia/emulator.cc
+++ b/src/xenia/emulator.cc
@@ -641,8 +641,8 @@ X_STATUS Emulator::CompleteLaunch(const std::wstring& path,
     return X_STATUS_UNSUCCESSFUL;
   }
 
-  on_launch();
   main_thread_ = main_xthread->thread();
+  on_launch();
 
   return X_STATUS_SUCCESS;
 }

--- a/src/xenia/ui/menu_item.h
+++ b/src/xenia/ui/menu_item.h
@@ -19,6 +19,8 @@
 namespace xe {
 namespace ui {
 
+class Window;
+
 class MenuItem {
  public:
   typedef std::unique_ptr<MenuItem, void (*)(MenuItem*)> MenuItemPtr;
@@ -50,6 +52,9 @@ class MenuItem {
   void AddChild(MenuItemPtr child_item);
   void RemoveChild(MenuItem* child_item);
   MenuItem* child(size_t index);
+
+  virtual void EnableMenuItem(Window& window) = 0;
+  virtual void DisableMenuItem(Window& window) = 0;
 
  protected:
   MenuItem(Type type, const std::wstring& text, const std::wstring& hotkey,

--- a/src/xenia/ui/window.h
+++ b/src/xenia/ui/window.h
@@ -44,6 +44,9 @@ class Window {
     OnMainMenuChange();
   }
 
+  virtual void EnableMainMenu() = 0;
+  virtual void DisableMainMenu() = 0;
+
   const std::wstring& title() const { return title_; }
   virtual bool set_title(const std::wstring& title) {
     if (title == title_) {

--- a/src/xenia/ui/window_win.cc
+++ b/src/xenia/ui/window_win.cc
@@ -163,6 +163,18 @@ void Win32Window::OnClose() {
   super::OnClose();
 }
 
+void Win32Window::EnableMainMenu() {
+  if (main_menu_) {
+    main_menu_->EnableMenuItem(*this);
+  }
+}
+
+void Win32Window::DisableMainMenu() {
+  if (main_menu_) {
+    main_menu_->DisableMenuItem(*this);
+  }
+}
+
 bool Win32Window::set_title(const std::wstring& title) {
   if (!super::set_title(title)) {
     return false;
@@ -626,6 +638,22 @@ Win32MenuItem::~Win32MenuItem() {
   if (handle_) {
     DestroyMenu(handle_);
   }
+}
+
+void Win32MenuItem::EnableMenuItem(Window& window) {
+  int i = 0;
+  for (auto iter = children_.begin(); iter != children_.end(); ++iter, i++) {
+    ::EnableMenuItem(handle_, i, MF_BYPOSITION | MF_ENABLED);
+  }
+  DrawMenuBar((HWND)window.native_handle());
+}
+
+void Win32MenuItem::DisableMenuItem(Window& window) {
+  int i = 0;
+  for (auto iter = children_.begin(); iter != children_.end(); ++iter, i++) {
+    ::EnableMenuItem(handle_, i, MF_BYPOSITION | MF_GRAYED);
+  }
+  DrawMenuBar((HWND)window.native_handle());
 }
 
 void Win32MenuItem::OnChildAdded(MenuItem* generic_child_item) {

--- a/src/xenia/ui/window_win.h
+++ b/src/xenia/ui/window_win.h
@@ -30,6 +30,9 @@ class Win32Window : public Window {
   NativeWindowHandle native_handle() const override { return hwnd_; }
   HWND hwnd() const { return hwnd_; }
 
+  void EnableMainMenu() override;
+  void DisableMainMenu() override;
+
   bool set_title(const std::wstring& title) override;
 
   bool SetIcon(const void* buffer, size_t size) override;
@@ -86,6 +89,9 @@ class Win32MenuItem : public MenuItem {
   ~Win32MenuItem() override;
 
   HMENU handle() { return handle_; }
+
+  void EnableMenuItem(Window& window) override;
+  void DisableMenuItem(Window& window) override;
 
   using MenuItem::OnSelected;
 


### PR DESCRIPTION
The menu bar on the main window is now greyed out until the emulator is completely initialized.

This is a slightly hacky fix, it would probably be better to make the dependency between the emulator and the window one-way so a proper wait can be done during the initialization phase. However, currently they are both pretty entangled so I'm not sure that'd be worth doing until Xenia has a more permanent UI.

Fixes issue #702 