### PR TITLE
Fixed Vulkan's dark color issue.

### DIFF
--- a/src/xenia/gpu/vulkan/texture_cache.cc
+++ b/src/xenia/gpu/vulkan/texture_cache.cc
@@ -51,9 +51,9 @@ static const TextureConfig texture_configs[64] = {
     {TextureFormat::k_4_4_4_4, VK_FORMAT_R4G4B4A4_UNORM_PACK16},
     {TextureFormat::k_10_11_11, VK_FORMAT_B10G11R11_UFLOAT_PACK32},  // ?
     {TextureFormat::k_11_11_10, VK_FORMAT_B10G11R11_UFLOAT_PACK32},  // ?
-    {TextureFormat::k_DXT1, VK_FORMAT_BC1_RGBA_SRGB_BLOCK},
-    {TextureFormat::k_DXT2_3, VK_FORMAT_BC2_SRGB_BLOCK},
-    {TextureFormat::k_DXT4_5, VK_FORMAT_BC3_SRGB_BLOCK},
+    {TextureFormat::k_DXT1, VK_FORMAT_BC1_RGBA_UNORM_BLOCK},
+    {TextureFormat::k_DXT2_3, VK_FORMAT_BC2_UNORM_BLOCK},
+    {TextureFormat::k_DXT4_5, VK_FORMAT_BC3_UNORM_BLOCK},
     {TextureFormat::kUnknown, VK_FORMAT_UNDEFINED},
     {TextureFormat::k_24_8, VK_FORMAT_D24_UNORM_S8_UINT},
     {TextureFormat::k_24_8_FLOAT, VK_FORMAT_D24_UNORM_S8_UINT},  // ?


### PR DESCRIPTION
It turns out the wrong color format for DXT caused this issue.
Before:
![vulkan_shadow](https://user-images.githubusercontent.com/1924514/28354919-52275f7e-6c94-11e7-93df-960b617cfa17.png)
After:
![lightfix](https://user-images.githubusercontent.com/1924514/28354864-1f0d31e0-6c94-11e7-9175-7c9144c50795.png)

The water reflection is still incorrect, will look into that later.