### PR TITLE
Fixed white edge on some textures(text display).

### DIFF
--- a/src/xenia/gpu/vulkan/texture_cache.cc
+++ b/src/xenia/gpu/vulkan/texture_cache.cc
@@ -264,7 +264,7 @@ void TextureCache::SetupEmptySet() {
   sampler_info.compareOp = VK_COMPARE_OP_NEVER;
   sampler_info.minLod = 0.f;
   sampler_info.maxLod = 0.f;
-  sampler_info.borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK;
+  sampler_info.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
   sampler_info.unnormalizedCoordinates = VK_FALSE;
   err = vkCreateSampler(*device_, &sampler_info, nullptr, &empty_sampler_);
   CheckResult(err, "vkCreateSampler");
@@ -797,7 +797,7 @@ TextureCache::Sampler* TextureCache::Demand(const SamplerInfo& sampler_info) {
   sampler_create_info.compareOp = VK_COMPARE_OP_NEVER;
   sampler_create_info.minLod = 0.0f;
   sampler_create_info.maxLod = 0.0f;
-  sampler_create_info.borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK;
+  sampler_create_info.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
   sampler_create_info.unnormalizedCoordinates = VK_FALSE;
   VkSampler vk_sampler;
   status =


### PR DESCRIPTION
Set borderColor to transparent to get rid of white edges on some textures(mainly text).

Before:
![fontfix](https://user-images.githubusercontent.com/1924514/28374993-ea721c26-6cd8-11e7-941a-063f4562b82d.png)
![fontfix5](https://user-images.githubusercontent.com/1924514/28375012-f361f9be-6cd8-11e7-93d0-6973c3710cf6.png)

After:
![fontfix2](https://user-images.githubusercontent.com/1924514/28375037-064221f8-6cd9-11e7-9d3d-793c58cf31b3.png)
![fontfix3](https://user-images.githubusercontent.com/1924514/28375076-1ca0567c-6cd9-11e7-8789-41088e846a32.png)
