### PR TITLE
Recognize OpenGL 4.60

### DIFF
--- a/src/xenia/ui/gl/gl_context.cc
+++ b/src/xenia/ui/gl/gl_context.cc
@@ -286,7 +286,7 @@ void GLContext::AssertExtensionsPresent() {
   auto glsl_version_raw =
       reinterpret_cast<const char*>(glGetString(GL_SHADING_LANGUAGE_VERSION));
   std::string glsl_version(glsl_version_raw);
-  if (glsl_version.find("4.50") != 0) {
+  if (glsl_version.find("4.6") != 0)) {
     FatalGLError("OpenGL GLSL version 4.50 is required.");
     return;
   }


### PR DESCRIPTION
A suitably easy fix is to change line 289 of gl_context.cc to:

if ((glsl_version.find("4.5") != 0) && (glsl_version.find("4.6") != 0))