### PR TITLE
Detect OpenGL 4.60

### DIFF
--- a/src/xenia/ui/gl/gl_context.cc
+++ b/src/xenia/ui/gl/gl_context.cc
@@ -286,7 +286,7 @@ void GLContext::AssertExtensionsPresent() {
   auto glsl_version_raw =
       reinterpret_cast<const char*>(glGetString(GL_SHADING_LANGUAGE_VERSION));
   std::string glsl_version(glsl_version_raw);
-  if (glsl_version.find("4.50") != 0 && glsl_version.find("4.60") != 0) {
+  if (glsl_version.find("4.5") != 0 && glsl_version.find("4.6") != 0) {
     FatalGLError("OpenGL GLSL version 4.50 or higher is required.");
     return;
   }

--- a/src/xenia/ui/gl/gl_context.cc
+++ b/src/xenia/ui/gl/gl_context.cc
@@ -286,7 +286,7 @@ void GLContext::AssertExtensionsPresent() {
   auto glsl_version_raw =
       reinterpret_cast<const char*>(glGetString(GL_SHADING_LANGUAGE_VERSION));
   std::string glsl_version(glsl_version_raw);
-  if (glsl_version.find("4.5") != 0 && glsl_version.find("4.6") != 0) {
+  if (glsl_version.find("4.5") == -1 && glsl_version.find("4.6") == -1) {
     FatalGLError("OpenGL GLSL version 4.50 or higher is required.");
     return;
   }

--- a/src/xenia/ui/gl/gl_context.cc
+++ b/src/xenia/ui/gl/gl_context.cc
@@ -286,7 +286,7 @@ void GLContext::AssertExtensionsPresent() {
   auto glsl_version_raw =
       reinterpret_cast<const char*>(glGetString(GL_SHADING_LANGUAGE_VERSION));
   std::string glsl_version(glsl_version_raw);
-  if (glsl_version.find("4.5") == -1 && glsl_version.find("4.6") == -1) {
+  if (glsl_version.find("4.5") == std::string::npos && glsl_version.find("4.6") == std::string::npos) {
     FatalGLError("OpenGL GLSL version 4.50 or higher is required.");
     return;
   }

--- a/src/xenia/ui/gl/gl_context.cc
+++ b/src/xenia/ui/gl/gl_context.cc
@@ -286,8 +286,8 @@ void GLContext::AssertExtensionsPresent() {
   auto glsl_version_raw =
       reinterpret_cast<const char*>(glGetString(GL_SHADING_LANGUAGE_VERSION));
   std::string glsl_version(glsl_version_raw);
-  if (glsl_version.find("4.50") != 0) {
-    FatalGLError("OpenGL GLSL version 4.50 is required.");
+  if (glsl_version.find("4.50") != 0 && glsl_version.find("4.60") != 0) {
+    FatalGLError("OpenGL GLSL version 4.50 or higher is required.");
     return;
   }
 


### PR DESCRIPTION
This change allows Xenia to detect if the system has OpenGL 4.6