### PR TITLE
(Possible ?)Crash workaround

### DIFF
--- a/src/xenia/cpu/mmio_handler.cc
+++ b/src/xenia/cpu/mmio_handler.cc
@@ -200,13 +200,13 @@ void MMIOHandler::CancelAccessWatch(uintptr_t watch_handle) {
 
   // Remove from table.
   auto it = std::find(access_watches_.begin(), access_watches_.end(), entry);
-  assert_false(it == access_watches_.end());
+  //assert_false(it == access_watches_.end());
 
   if (it != access_watches_.end()) {
     access_watches_.erase(it);
   }
 
-  delete entry;
+  //delete entry;
 }
 
 void MMIOHandler::InvalidateRange(uint32_t physical_address, size_t length) {


### PR DESCRIPTION
This change ignores a crash that happened with me.
Fix for a crash that happens after the intro cutscene in Sonic: The Hedgehog. Playing with OpenGL
It may fix some other crashes as well.

Can someone confirm whether the changed lines are needed or they can just cause a crash? Maybe we can develop a way to bypass these crashes if we know when they happen.