### PR TITLE
Allow computers with non-latin native codepages to build the project.

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -119,6 +119,7 @@ filter("platforms:Windows")
     "/wd4127",  -- 'conditional expression is constant'.
     "/wd4324",  -- 'structure was padded due to alignment specifier'.
     "/wd4189",  -- 'local variable is initialized but not referenced'.
+    "/utf-8",   -- 'build correctly on systems with non-Latin codepages'.
   })
   flags({
     "NoMinimalRebuild", -- Required for /MP above.


### PR DESCRIPTION
Thanks to @yxmline from #812 
As someone with a Japanese copy of Windows, I need this change to build the project.