### PR TITLE
AMD Crash Fix (Use with c1e8c3b)

### DIFF
--- a/src/xenia/gpu/vulkan/render_cache.cc
+++ b/src/xenia/gpu/vulkan/render_cache.cc
@@ -62,7 +62,7 @@ VkFormat ColorRenderTargetFormatToVkFormat(ColorRenderTargetFormat format) {
 VkFormat DepthRenderTargetFormatToVkFormat(DepthRenderTargetFormat format) {
   switch (format) {
     case DepthRenderTargetFormat::kD24S8:
-      return VK_FORMAT_D24_UNORM_S8_UINT;
+      return VK_FORMAT_D32_SFLOAT_S8_UINT;
     case DepthRenderTargetFormat::kD24FS8:
       // Vulkan doesn't support 24-bit floats, so just promote it to 32-bit
       return VK_FORMAT_D32_SFLOAT_S8_UINT;


### PR DESCRIPTION
Change Depth Render Target From 24-Bit to 32-Bit

c1e8c3b
Change Texture Depth from 24-Bit to 32-Bit

Fixes #756 