### PR TITLE
fix constant propagation creating invalid instructions

### DIFF
--- a/src/xenia/cpu/compiler/passes/constant_propagation_pass.cc
+++ b/src/xenia/cpu/compiler/passes/constant_propagation_pass.cc
@@ -510,7 +510,10 @@ bool ConstantPropagationPass::Run(HIRBuilder* builder) {
               mul->Mul(i->src2.value);
 
               Value* add = i->src3.value;
-              i->Replace(&OPCODE_ADD_info, 0);
+              if (mul->type == VEC128_TYPE)
+                i->Replace(&OPCODE_VECTOR_ADD_info, FLOAT32_TYPE);
+              else
+                i->Replace(&OPCODE_ADD_info, 0);
               i->set_src1(mul);
               i->set_src2(add);
             }
@@ -530,7 +533,10 @@ bool ConstantPropagationPass::Run(HIRBuilder* builder) {
               mul->Mul(i->src2.value);
 
               Value* add = i->src3.value;
-              i->Replace(&OPCODE_SUB_info, 0);
+              if (mul->type == VEC128_TYPE)
+                i->Replace(&OPCODE_VECTOR_SUB_info, FLOAT32_TYPE);
+              else
+                i->Replace(&OPCODE_SUB_info, 0);
               i->set_src1(mul);
               i->set_src2(add);
             }


### PR DESCRIPTION
The constant propagation pass seems to be creating new add/sub instructions that have vector parameters instead of using vector_add/sub, causing dark souls 2 to crash. With this fix it goes a little further and hangs on the intro videos.